### PR TITLE
Checking for intersection on transitionend/animationend

### DIFF
--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -254,6 +254,8 @@ IntersectionObserver.prototype._monitorIntersections = function() {
     else {
       addEvent(window, 'resize', this._checkForIntersections, true);
       addEvent(document, 'scroll', this._checkForIntersections, true);
+      addEvent(document, 'transitionend', this._checkForIntersections, true);
+      addEvent(document, 'animationend', this._checkForIntersections, true);
 
       if ('MutationObserver' in window) {
         this._domObserver = new MutationObserver(this._checkForIntersections);


### PR DESCRIPTION
The polyfill checks for intersections when `animationend` or `transitionend` events are fired. Not only on `resize` or `scroll`. Doing these new checks should still be cheap, because these events are only fired once the movement of the element is finished.