### PR TITLE
Look for intersectionRatio on the global IntersectionObserverEntry

### DIFF
--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -22,7 +22,7 @@
 // features are natively supported.
 if ('IntersectionObserver' in window &&
     'IntersectionObserverEntry' in window &&
-    'intersectionRatio' in IntersectionObserverEntry.prototype) {
+    'intersectionRatio' in window.IntersectionObserverEntry.prototype) {
 
   // Minimal polyfill for Edge 15's lack of `isIntersecting`
   // See: https://github.com/WICG/IntersectionObserver/issues/211

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -26,7 +26,7 @@ if ('IntersectionObserver' in window &&
 
   // Minimal polyfill for Edge 15's lack of `isIntersecting`
   // See: https://github.com/WICG/IntersectionObserver/issues/211
-  if (!('isIntersecting' in IntersectionObserverEntry.prototype)) {
+  if (!('isIntersecting' in window.IntersectionObserverEntry.prototype)) {
     Object.defineProperty(IntersectionObserverEntry.prototype,
       'isIntersecting', {
       get: function () {

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -27,7 +27,7 @@ if ('IntersectionObserver' in window &&
   // Minimal polyfill for Edge 15's lack of `isIntersecting`
   // See: https://github.com/WICG/IntersectionObserver/issues/211
   if (!('isIntersecting' in window.IntersectionObserverEntry.prototype)) {
-    Object.defineProperty(IntersectionObserverEntry.prototype,
+    Object.defineProperty(window.IntersectionObserverEntry.prototype,
       'isIntersecting', {
       get: function () {
         return this.intersectionRatio > 0;


### PR DESCRIPTION
Currently looks at the local IntersectionObserverEntry's prototype when doing feature detection rather than the global (native) constructor function.

Fixes #234 