### PR TITLE
Check for intersections each time a node is observed

### DIFF
--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -178,6 +178,20 @@ describe('IntersectionObserver', function() {
       io.observe(targetEl2);
     });
 
+    it('triggers for existing targets when observing begins after monitoring has begun', function(done) {
+      var spy = sinon.spy();
+      io = new IntersectionObserver(spy, {root: rootEl});
+
+      io.observe(targetEl1);
+      setTimeout(function() {
+        io.observe(targetEl2);
+        setTimeout(function() {
+          expect(spy.callCount).to.be(2);
+          done();
+        }, ASYNC_TIMEOUT);
+      }, ASYNC_TIMEOUT);
+    });
+
 
     it('triggers with the correct arguments', function(done) {
       io = new IntersectionObserver(function(records, observer) {

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -257,8 +257,6 @@ IntersectionObserver.prototype._monitorIntersections = function() {
   if (!this._monitoringIntersections) {
     this._monitoringIntersections = true;
 
-    this._checkForIntersections();
-
     // If a poll interval is set, use polling instead of listening to
     // resize and scroll events or DOM mutations.
     if (this.POLL_INTERVAL) {

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -152,6 +152,7 @@ IntersectionObserver.prototype.observe = function(target) {
   this._registerInstance();
   this._observationTargets.push({element: target, entry: null});
   this._monitorIntersections();
+  this._checkForIntersections();
 };
 
 


### PR DESCRIPTION
If a node is being observed that was already in DOM and monitoring has already begun, an intersection check must be performed to the throttled `_checkForIntersections`.

Fixes #238 