### PR TITLE
Add intersectionRatio and isIntersecting to the prototype

### DIFF
--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -59,23 +59,38 @@ function IntersectionObserverEntry(entry) {
   this.rootBounds = entry.rootBounds;
   this.boundingClientRect = entry.boundingClientRect;
   this.intersectionRect = entry.intersectionRect || getEmptyRect();
-  this.isIntersecting = !!entry.intersectionRect;
-
-  // Calculates the intersection ratio.
-  var targetRect = this.boundingClientRect;
-  var targetArea = targetRect.width * targetRect.height;
-  var intersectionRect = this.intersectionRect;
-  var intersectionArea = intersectionRect.width * intersectionRect.height;
-
-  // Sets intersection ratio.
-  if (targetArea) {
-    this.intersectionRatio = intersectionArea / targetArea;
-  } else {
-    // If area is zero and is intersecting, sets to 1, otherwise to 0
-    this.intersectionRatio = this.isIntersecting ? 1 : 0;
-  }
+  
+  // Private properties.
+  this._entry = entry;
 }
 
+Object.defineProperty(IntersectionObserverEntry.prototype,
+  'intersectionRatio', {
+    get: function () {
+      // Calculates the intersection ratio.
+      var targetRect = this.boundingClientRect;
+      var targetArea = targetRect.width * targetRect.height;
+      var intersectionRect = this.intersectionRect;
+      var intersectionArea = intersectionRect.width * intersectionRect.height;
+
+      // Sets intersection ratio.
+      if (targetArea) {
+        return intersectionArea / targetArea;
+      } else {
+        // If area is zero and is intersecting, sets to 1, otherwise to 0
+        return this.isIntersecting ? 1 : 0;
+      }
+    }
+  }
+);
+
+Object.defineProperty(IntersectionObserverEntry.prototype,
+  'isIntersecting', {
+    get: function () {
+      return !!this._entry.intersectionRect;
+    }
+  }
+);
 
 /**
  * Creates the global IntersectionObserver constructor.


### PR DESCRIPTION
Adding these to the prototype will make sure that basic feature detection will pass for the polyfilled version of IntersectionObservers.

Running this on a browser which has IntersectionObserver natively will return true but on a browser with the polyfill will currently return false.
```
'IntersectionObserver' in this &&
'IntersectionObserverEntry' in this &&
'intersectionRatio' in this.IntersectionObserverEntry.prototype &&
'isIntersecting' in this.IntersectionObserverEntry.prototype
```