### PR TITLE
Use rAF with a timeout of 0 and test

### DIFF
--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -805,6 +805,35 @@ describe('IntersectionObserver', function() {
       io.observe(targetEl1);
     });
 
+
+    it('uses requestAnimationFrame when timeout is 0', function(done) {
+      var rAF = window.requestAnimationFrame;
+      if (!rAF) {
+        done();
+      }
+      else {
+        var timeout = IntersectionObserver.prototype.THROTTLE_TIMEOUT;
+        var stub = sinon.stub(window, 'requestAnimationFrame').returns(1);
+
+        // without a THROTTLE_TIMEOUT of 0, setTimeout should be used
+        IntersectionObserver.prototype.THROTTLE_TIMEOUT = timeout || 100;
+        io = new IntersectionObserver(function() {}, {root: rootEl});
+        io.observe(targetEl1);
+        expect(stub.callCount).to.be(0);
+        io.disconnect();
+
+        // when THROTTLE_TIMEOUT is 0 and requestAnimationFrame is available, it should be used
+        IntersectionObserver.prototype.THROTTLE_TIMEOUT = 0;
+        io = new IntersectionObserver(function() {}, {root: rootEl});
+        io.observe(targetEl1);
+        expect(stub.callCount).to.be(1);
+
+        window.requestAnimationFrame = rAF;
+        IntersectionObserver.prototype.THROTTLE_TIMEOUT = timeout;
+        done();
+      }
+    });
+
   });
 
 

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -552,7 +552,7 @@ function now() {
 
 
 /**
- * Throttles a function and delays its executiong, so it's only called at most
+ * Throttles a function and delays its execution, so it's only called at most
  * once within a given time period.
  * @param {Function} fn The function to throttle.
  * @param {number} timeout The amount of time that must pass before the
@@ -563,10 +563,16 @@ function throttle(fn, timeout) {
   var timer = null;
   return function () {
     if (!timer) {
-      timer = setTimeout(function() {
+      var callback = function() {
         fn();
         timer = null;
-      }, timeout);
+      };
+      if (timeout == 0 && window.requestAnimationFrame) {
+        timer = requestAnimationFrame(callback);
+      }
+      else {
+        timer = setTimeout(callback, timeout);
+      }
     }
   };
 }


### PR DESCRIPTION
Use `requestAnimationFrame` instead of `setTimeout` when `THROTTLE_TIMEOUT` is 0 and the API is available. Added test.

Resolves #248.