### PR TITLE
Change links that point at WICG to point at w3c

### DIFF
--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -1,6 +1,6 @@
 # `IntersectionObserver` polyfill
 
-This library polyfills the native [`IntersectionObserver`](http://wicg.github.io/IntersectionObserver/) API in unsupporting browsers. See the [API documentation](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) for usage information.
+This library polyfills the native [`IntersectionObserver`](http://w3c.github.io/IntersectionObserver/) API in unsupporting browsers. See the [API documentation](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) for usage information.
 
 - [Installation](#installation)
 - [Configuring the polyfill](#configuring-the-polyfill)
@@ -9,7 +9,7 @@ This library polyfills the native [`IntersectionObserver`](http://wicg.github.io
 
 ## Installation
 
-You can install the polyfill via npm or by downloading a [zip](https://github.com/WICG/IntersectionObserver/archive/gh-pages.zip) of this repository:
+You can install the polyfill via npm or by downloading a [zip](https://github.com/w3c/IntersectionObserver/archive/gh-pages.zip) of this repository:
 
 ```sh
 npm install intersection-observer

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -646,7 +646,7 @@ describe('IntersectionObserver', function() {
 
       // targetEl5 is initially not in the DOM. Note that this element must be
       // created outside of the addFixtures() function to catch the IE11 error
-      // described here: https://github.com/WICG/IntersectionObserver/pull/205
+      // described here: https://github.com/w3c/IntersectionObserver/pull/205
       var targetEl5 = document.createElement('div');
       targetEl5.setAttribute('id', 'target5');
 

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -25,7 +25,7 @@ if ('IntersectionObserver' in window &&
     'intersectionRatio' in window.IntersectionObserverEntry.prototype) {
 
   // Minimal polyfill for Edge 15's lack of `isIntersecting`
-  // See: https://github.com/WICG/IntersectionObserver/issues/211
+  // See: https://github.com/w3c/IntersectionObserver/issues/211
   if (!('isIntersecting' in window.IntersectionObserverEntry.prototype)) {
     Object.defineProperty(window.IntersectionObserverEntry.prototype,
       'isIntersecting', {
@@ -49,7 +49,7 @@ var registry = [];
 
 /**
  * Creates the global IntersectionObserverEntry constructor.
- * https://wicg.github.io/IntersectionObserver/#intersection-observer-entry
+ * https://w3c.github.io/IntersectionObserver/#intersection-observer-entry
  * @param {Object} entry A dictionary of instance properties.
  * @constructor
  */
@@ -79,7 +79,7 @@ function IntersectionObserverEntry(entry) {
 
 /**
  * Creates the global IntersectionObserver constructor.
- * https://wicg.github.io/IntersectionObserver/#intersection-observer-interface
+ * https://w3c.github.io/IntersectionObserver/#intersection-observer-interface
  * @param {Function} callback The function to be invoked after intersection
  *     changes have queued. The function is not invoked if the queue has
  *     been emptied by calling the `takeRecords` method.
@@ -357,7 +357,7 @@ IntersectionObserver.prototype._checkForIntersections = function() {
  * Accepts a target and root rect computes the intersection between then
  * following the algorithm in the spec.
  * TODO(philipwalton): at this time clip-path is not considered.
- * https://wicg.github.io/IntersectionObserver/#calculate-intersection-rect-algo
+ * https://w3c.github.io/IntersectionObserver/#calculate-intersection-rect-algo
  * @param {Element} target The target DOM element
  * @param {Object} rootRect The bounding rect of the root after being
  *     expanded by the rootMargin value.
@@ -646,7 +646,7 @@ function getBoundingClientRect(el) {
     rect = el.getBoundingClientRect();
   } catch (err) {
     // Ignore Windows 7 IE11 "Unspecified error"
-    // https://github.com/WICG/IntersectionObserver/pull/205
+    // https://github.com/w3c/IntersectionObserver/pull/205
   }
 
   if (!rect) return getEmptyRect();

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -5,7 +5,7 @@
   "main": "intersection-observer",
   "repository": {
     "type": "git",
-    "url": "git@github.com:WICG/IntersectionObserver.git"
+    "url": "git@github.com:w3c/IntersectionObserver.git"
   },
   "keywords": [
     "Intersection",
@@ -18,6 +18,6 @@
   },
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/WICG/IntersectionObserver/issues"
+    "url": "https://github.com/w3c/IntersectionObserver/issues"
   }
 }


### PR DESCRIPTION
Now that the spec has moved from https://github.com/WICG to https://github.com/w3c there are a few parts of the code and documentation that need updating. Some redirect automatically, but others currently 404.