### PR TITLE
Make mutation observer optional & better confined

### DIFF
--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -131,6 +131,12 @@ IntersectionObserver.prototype.THROTTLE_TIMEOUT = 100;
  */
 IntersectionObserver.prototype.POLL_INTERVAL = null;
 
+/**
+ * Use a mutation observer on the root element 
+ * to detect intersection changes.
+ */
+IntersectionObserver.prototype.USE_MUTATION_OBSERVER = true;
+
 
 /**
  * Starts observing a target element for intersection changes based on
@@ -267,9 +273,9 @@ IntersectionObserver.prototype._monitorIntersections = function() {
       addEvent(window, 'resize', this._checkForIntersections, true);
       addEvent(document, 'scroll', this._checkForIntersections, true);
 
-      if ('MutationObserver' in window) {
+      if (this.USE_MUTATION_OBSERVER && 'MutationObserver' in window) {
         this._domObserver = new MutationObserver(this._checkForIntersections);
-        this._domObserver.observe(document, {
+        this._domObserver.observe(this.root || document, {
           attributes: true,
           childList: true,
           characterData: true,


### PR DESCRIPTION
2 changes: 

1. Make mutation observer optional (solves #261) because it is rarely needed
2. Use `root` options to prevent observing the all document when only a tiny part is scrollable. Prevent triggering unnecessary check on intersection when somewhere the document is highly dynamic.