### PR TITLE
Prevent setting the polyfill multiple times on further loads

### DIFF
--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -69,6 +69,10 @@ function IntersectionObserverEntry(entry) {
   }
 }
 
+/**
+ * Prevent setting the polyfill multiple times on further loads
+ */
+IntersectionObserverEntry.prototype.intersectionRatio = 0;
 
 /**
  * Creates the global IntersectionObserver constructor.

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -73,6 +73,7 @@ function IntersectionObserverEntry(entry) {
  * Prevent setting the polyfill multiple times on further loads
  */
 IntersectionObserverEntry.prototype.intersectionRatio = undefined;
+IntersectionObserverEntry.prototype.isIntersecting = undefined;
 
 /**
  * Creates the global IntersectionObserver constructor.

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -72,7 +72,7 @@ function IntersectionObserverEntry(entry) {
 /**
  * Prevent setting the polyfill multiple times on further loads
  */
-IntersectionObserverEntry.prototype.intersectionRatio = 0;
+IntersectionObserverEntry.prototype.intersectionRatio = undefined;
 
 /**
  * Creates the global IntersectionObserver constructor.


### PR DESCRIPTION
When the IntersectionObserver polyfill is loaded multiple times it should not be reset.

Due to this check https://github.com/w3c/IntersectionObserver/blob/master/polyfill/intersection-observer.js#L18 the polyfill will be overwritten on every load.