### PR TITLE
Judgement target's nodeType at first

### DIFF
--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -161,9 +161,7 @@ IntersectionObserver.prototype.observe = function(target) {
  * @param {Element} target The DOM element to observe.
  */
 IntersectionObserver.prototype.unobserve = function(target) {
-  this._observationTargets =
-      this._observationTargets.filter(function(item) {
-
+  this._observationTargets = this._observationTargets.filter(function(item) {
     return item.element != target;
   });
   if (!this._observationTargets.length) {

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -137,16 +137,16 @@ IntersectionObserver.prototype.USE_MUTATION_OBSERVER = true;
  * @param {Element} target The DOM element to observe.
  */
 IntersectionObserver.prototype.observe = function(target) {
+  if (!(target && target.nodeType == 1)) {
+    throw new Error('target must be an Element');
+  }
+
   var isTargetAlreadyObserved = this._observationTargets.some(function(item) {
     return item.element == target;
   });
 
   if (isTargetAlreadyObserved) {
     return;
-  }
-
-  if (!(target && target.nodeType == 1)) {
-    throw new Error('target must be an Element');
   }
 
   this._registerInstance();


### PR DESCRIPTION
Hello,

I think it's more logical to validate the target's type at first, then checks if it is already observed.

Thanks.