### PR TITLE
Fix lifetime specification for IntersectionObserver instances

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -647,13 +647,7 @@ An {{IntersectionObserver}} will remain alive until both of these conditions hol
 	<li>The observer is not observing any targets.
 </ul>
 
-An {{IntersectionObserver}} will continue observing a target until any of the following occurs:
-<ul>
-	<li>{{IntersectionObserver/unobserve(target)}} is called on the target.</li>
-	<li>{{IntersectionObserver/disconnect()}} is called.</li>
-	<li>The target {{Element}} is deleted.</li>
-	<li>The observer's <a>intersection root</a> is deleted.
-</ul>
+An {{IntersectionObserver}} will continue observing a target until either {{IntersectionObserver/unobserve(target)}} is called on the target, or {{IntersectionObserver/disconnect()}} is called on the observer.
 
 <h3 id='external-spec-integrations'>
 External Spec Integrations</h3>


### PR DESCRIPTION
There is no 'delete'; there is only 'remove'.

Issue #275 