### PR TITLE
allow IntersectionObserver polyfill to get loaded in an iframe 

### DIFF
--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -9,24 +9,27 @@
 
 (function(window, document) {
 'use strict';
-
+var _loadedWindowOrIFrame = window;
+window = window.top;
+document = window.document;
 
 // Exits early if all IntersectionObserver and IntersectionObserverEntry
 // features are natively supported.
-if ('IntersectionObserver' in window &&
-    'IntersectionObserverEntry' in window &&
-    'intersectionRatio' in window.IntersectionObserverEntry.prototype) {
+if ('IntersectionObserver' in _loadedWindowOrIFrame &&
+    'IntersectionObserverEntry' in _loadedWindowOrIFrame &&
+    'intersectionRatio' in _loadedWindowOrIFrame.IntersectionObserverEntry.prototype) {
 
   // Minimal polyfill for Edge 15's lack of `isIntersecting`
   // See: https://github.com/w3c/IntersectionObserver/issues/211
-  if (!('isIntersecting' in window.IntersectionObserverEntry.prototype)) {
-    Object.defineProperty(window.IntersectionObserverEntry.prototype,
+  if (!('isIntersecting' in _loadedWindowOrIFrame.IntersectionObserverEntry.prototype)) {
+    Object.defineProperty(_loadedWindowOrIFrame.IntersectionObserverEntry.prototype,
       'isIntersecting', {
       get: function () {
         return this.intersectionRatio > 0;
       }
     });
   }
+
   return;
 }
 
@@ -718,7 +721,7 @@ function getParentNode(node) {
 
 
 // Exposes the constructors globally.
-window.IntersectionObserver = IntersectionObserver;
-window.IntersectionObserverEntry = IntersectionObserverEntry;
+_loadedWindowOrIFrame.IntersectionObserver = IntersectionObserver;
+_loadedWindowOrIFrame.IntersectionObserverEntry = IntersectionObserverEntry;
 
 }(window, document));


### PR DESCRIPTION
This fix is possibly related to issue #297 

When the polyfill is loaded inside an <iframe> with the `root` option set to `null` then the root viewport is  the <iframe> itself and therefore does not track any activity on the parent/host window. This was observed on both mobile and desktop versions of Safari. 
However, this is not the default behavior for `IntersectionObserver` on browsers with native support e.g. Chrome, in which case the `root` viewport is correctly calculated with respect to the top window. 