### PR TITLE
Rounding polyfill intersection ratio to 3 decimals

### DIFF
--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -62,7 +62,7 @@ function IntersectionObserverEntry(entry) {
 
   // Sets intersection ratio.
   if (targetArea) {
-    this.intersectionRatio = (intersectionArea / targetArea).toFixed(3) - 0;
+    this.intersectionRatio = Number((intersectionArea / targetArea).toFixed(4));
   } else {
     // If area is zero and is intersecting, sets to 1, otherwise to 0
     this.intersectionRatio = this.isIntersecting ? 1 : 0;

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -62,7 +62,7 @@ function IntersectionObserverEntry(entry) {
 
   // Sets intersection ratio.
   if (targetArea) {
-    this.intersectionRatio = intersectionArea / targetArea;
+    this.intersectionRatio = (intersectionArea / targetArea).toFixed(3) - 0;
   } else {
     // If area is zero and is intersecting, sets to 1, otherwise to 0
     this.intersectionRatio = this.isIntersecting ? 1 : 0;


### PR DESCRIPTION
In the intersection observer draft, it talks about threshold as a ratio using examples of 1 decimal only. 
I thought of 3 decimals as I normally think on the intersection ratio as a percentage of the area so we can match thresholds up to 3 decimals (or percentages up to 1 decimal).

https://github.com/w3c/IntersectionObserver/issues/324