### PR TITLE
Fixes Polyfill broken on Shadow DOM

### DIFF
--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -724,6 +724,30 @@ describe('IntersectionObserver', function() {
 
         io.observe(targetEl1);
       });
+
+      it('handles roots in shadow DOM', function(done) {
+        var shadowRoot = grandParentEl.attachShadow({mode: 'open'});
+
+        shadowRoot.innerHTML =
+        '<style>' +
+          '#slot-parent {' +
+          '  position: relative;' +
+          '  width: 400px;' +
+          '  height: 200px;' +
+          '}' +
+        '</style>' +
+        '<div id="slot-parent"><slot></slot></div>';
+
+        var slotParent = shadowRoot.getElementById('slot-parent');
+
+        io = new IntersectionObserver(function(records) {
+          expect(records.length).to.be(1);
+          expect(records[0].intersectionRatio).to.be(1);
+          done();
+        }, {root: slotParent});
+
+        io.observe(targetEl1);
+      });
     }
 
 

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -696,6 +696,12 @@ function containsDeep(parent, child) {
 
     node = getParentNode(node);
   }
+
+  if (parent && parent.assignedSlot) {
+    // If the parent is distributed in a <slot>, return the parent of a slot.
+    return parent.assignedSlot.parentNode;
+  }
+
   return false;
 }
 


### PR DESCRIPTION
Fixes #303
Makes the Polyfill to take into account shadow parts of a DOM tree when iterating parent nodes.