### PR TITLE
 Modify IIFE to safely execute in Node environments

### DIFF
--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -729,4 +729,4 @@ function getParentNode(node) {
 root.IntersectionObserver = IntersectionObserver;
 root.IntersectionObserverEntry = IntersectionObserverEntry;
 
-}(this));
+}(typeof window !== "undefined" ? window : this));

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -7,20 +7,20 @@
  *
  */
 
-(function(window, document) {
+(function(root) {
 'use strict';
 
 
 // Exits early if all IntersectionObserver and IntersectionObserverEntry
 // features are natively supported.
-if ('IntersectionObserver' in window &&
-    'IntersectionObserverEntry' in window &&
-    'intersectionRatio' in window.IntersectionObserverEntry.prototype) {
+if ('IntersectionObserver' in root &&
+    'IntersectionObserverEntry' in root &&
+    'intersectionRatio' in root.IntersectionObserverEntry.prototype) {
 
   // Minimal polyfill for Edge 15's lack of `isIntersecting`
   // See: https://github.com/w3c/IntersectionObserver/issues/211
-  if (!('isIntersecting' in window.IntersectionObserverEntry.prototype)) {
-    Object.defineProperty(window.IntersectionObserverEntry.prototype,
+  if (!('isIntersecting' in root.IntersectionObserverEntry.prototype)) {
+    Object.defineProperty(root.IntersectionObserverEntry.prototype,
       'isIntersecting', {
       get: function () {
         return this.intersectionRatio > 0;
@@ -266,10 +266,10 @@ IntersectionObserver.prototype._monitorIntersections = function() {
           this._checkForIntersections, this.POLL_INTERVAL);
     }
     else {
-      addEvent(window, 'resize', this._checkForIntersections, true);
-      addEvent(document, 'scroll', this._checkForIntersections, true);
+      addEvent(root, 'resize', this._checkForIntersections, true);
+      addEvent(root.document, 'scroll', this._checkForIntersections, true);
 
-      if (this.USE_MUTATION_OBSERVER && 'MutationObserver' in window) {
+      if (this.USE_MUTATION_OBSERVER && 'MutationObserver' in root) {
         this._domObserver = new MutationObserver(this._checkForIntersections);
         this._domObserver.observe(document, {
           attributes: true,
@@ -294,8 +294,8 @@ IntersectionObserver.prototype._unmonitorIntersections = function() {
     clearInterval(this._monitoringInterval);
     this._monitoringInterval = null;
 
-    removeEvent(window, 'resize', this._checkForIntersections, true);
-    removeEvent(document, 'scroll', this._checkForIntersections, true);
+    removeEvent(root, 'resize', this._checkForIntersections, true);
+    removeEvent(root.document, 'scroll', this._checkForIntersections, true);
 
     if (this._domObserver) {
       this._domObserver.disconnect();
@@ -371,7 +371,7 @@ IntersectionObserver.prototype._computeTargetAndRootIntersection =
     function(target, rootRect) {
 
   // If the element isn't displayed, an intersection can't happen.
-  if (window.getComputedStyle(target).display == 'none') return;
+  if (root.getComputedStyle(target).display == 'none') return;
 
   var targetRect = getBoundingClientRect(target);
   var intersectionRect = targetRect;
@@ -381,7 +381,7 @@ IntersectionObserver.prototype._computeTargetAndRootIntersection =
   while (!atRoot) {
     var parentRect = null;
     var parentComputedStyle = parent.nodeType == 1 ?
-        window.getComputedStyle(parent) : {};
+        root.getComputedStyle(parent) : {};
 
     // If the parent isn't displayed, an intersection can't happen.
     if (parentComputedStyle.display == 'none') return;
@@ -424,7 +424,7 @@ IntersectionObserver.prototype._getRootRect = function() {
   if (this.root) {
     rootRect = getBoundingClientRect(this.root);
   } else {
-    // Use <html>/<body> instead of window since scroll bars affect size.
+    // Use <html>/<body> instead of window (i.e. `root`) since scroll bars affect size.
     var html = document.documentElement;
     var body = document.body;
     rootRect = {
@@ -549,7 +549,7 @@ IntersectionObserver.prototype._unregisterInstance = function() {
  * @return {number} The elapsed time since the page was requested.
  */
 function now() {
-  return window.performance && performance.now && performance.now();
+  return root.performance && performance.now && performance.now();
 }
 
 
@@ -726,7 +726,7 @@ function getParentNode(node) {
 
 
 // Exposes the constructors globally.
-window.IntersectionObserver = IntersectionObserver;
-window.IntersectionObserverEntry = IntersectionObserverEntry;
+root.IntersectionObserver = IntersectionObserver;
+root.IntersectionObserverEntry = IntersectionObserverEntry;
 
-}(window, document));
+}(this));


### PR DESCRIPTION
## Description
This PR modifies the polyfill's IIFE wrapper to safely allow execution within a Node environment without `window` and `document` globals. The modified IIFE uses a combination of these techniques:

- [IIFE for non-browser global environments](https://toddmotto.com/what-function-window-document-undefined-iife-really-means/#non-browser-global-environments)
- Pass either `window` or `this` to the wrapped function, [as seen in jQuery's wrapper](https://github.com/jquery/jquery/blob/e743cbd28553267f955f71ea7248377915613fd9/src/wrapper.js#L41)

## Motivation + Background
I've been working on an internal project which uses this polyfill to support Safari on macOS and iOS for our usages of a React `<Observer>` component ([@kohlmannj/react-intersection-observer](
https://github.com/kohlmannj/react-intersection-observer)).

I started by statically importing the polyfill (e.g. `import 'intersection-observer';`), but found that our webpack and Node-based pre-render process (without JSDOM, so without `window` and `document` globals) exited with an error due to the polyfill's IIFE wrapper.

I then tried a few variations of the theme of dynamically `import()`ing of the polyfill client-side, and only in browsers that needed it. While this worked, it added significant complexity to our usage of the `<Observer>` component (since applying the polyfill is a global side effect, I identified some tricky React render order concerns).

Therefore, I finally went back to this polyfill to see if I could address the root cause of the Node pre-render's failure. I then researched and combined the two generally accepted approaches mentioned above to create the modified IIFE.

Finally, I noted that the test suite in intersection-observer-test.html passed all tests when run in Safari 12.0.2 (14606.3.4) on macOS Mojave 10.14.2. This suggests that the modifications have no impact on the polyfill's correctness when applied client-side.