### PR TITLE
Add `IntersectionObserver.prototype.IS_POLYFILL`

### DIFF
--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -132,6 +132,12 @@ IntersectionObserver.prototype.POLL_INTERVAL = null;
  */
 IntersectionObserver.prototype.USE_MUTATION_OBSERVER = true;
 
+/**
+ * Indicates that IntersectionObserver has been polyfilled, allowing
+ * other code to detect the presence of the polyfilled implementation.
+ */
+IntersectionObserver.prototype.IS_POLYFILL = true;
+
 
 /**
  * Starts observing a target element for intersection changes based on


### PR DESCRIPTION
This PR adds property `IS_POLYFILL` to the IntersectionObserver prototype. This allows code that runs after the polyfill to detect if the client-side IntersectionObserver implementation is non-native, e.g. in cases where the developer wants to disable certain behavior for performance reasons.