### PR TITLE
Clarifying how the first callback happens

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -712,6 +712,9 @@ To <dfn>run the update intersection observations steps</dfn> for a
 			passing in |observer|, |time|, |rootBounds|,
 			|boundingClientRect|, |intersectionRect|, |isIntersecting|,
 			|isVisible|, and |target|.
+
+			Note: The initial value of |registration|.{{IntersectionObserverRegistration/previousThresholdIndex}} is -1 but |thresholdIndex| will always be 0 or greater. This ensures an IntersectionObserverEntry is <em>always</em> queued for a new |target|.
+
 		15. Assign |threshold| to |registration|'s
 		    	{{IntersectionObserverRegistration/previousThresholdIndex}} property.
 		16. Assign |isIntersecting| to |registration|'s


### PR DESCRIPTION
It wasn't immediately clear to me how we always call the observer for a new target. I realised it's because `previousThresholdIndex` starts as -1, and it'll never calculate to that during the "update intersection observations steps".

I added a note that might make this clearer.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/pull/344.html" title="Last updated on Jan 31, 2019, 11:05 PM UTC (fe9aab6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/344/0af67f7...fe9aab6.html" title="Last updated on Jan 31, 2019, 11:05 PM UTC (fe9aab6)">Diff</a>