### PR TITLE
Fix possible exception in old Firefox versions

### DIFF
--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -380,7 +380,8 @@ IntersectionObserver.prototype._computeTargetAndRootIntersection =
     function(target, rootRect) {
 
   // If the element isn't displayed, an intersection can't happen.
-  if (window.getComputedStyle(target).display == 'none') return;
+  var targetComputedStyle = window.getComputedStyle(target);
+  if (!targetComputedStyle || targetComputedStyle.display == 'none') return;
 
   var targetRect = getBoundingClientRect(target);
   var intersectionRect = targetRect;


### PR DESCRIPTION
In older versions of Firefox, window.getComputedStyle may return null when element is invisible (see https://bugzilla.mozilla.org/show_bug.cgi?id=548397). This causes an exception in the polyfill

Closes #???

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
