### PR TITLE
Add explicit [Exposed] + default dictionary value

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -192,7 +192,7 @@ use-cases. Per-{{observe()}} options could be provided in the future if V2
 introduces a need for it.
 
 <pre class="idl">
-[Constructor(IntersectionObserverCallback callback, optional IntersectionObserverInit options),
+[Constructor(IntersectionObserverCallback callback, optional IntersectionObserverInit options = {}),
  Exposed=Window]
 interface IntersectionObserver {
 	readonly attribute Element? root;
@@ -365,7 +365,8 @@ or failure:
 The IntersectionObserverEntry interface</h3>
 
 <pre class="idl">
-[Constructor(IntersectionObserverEntryInit intersectionObserverEntryInit)]
+[Constructor(IntersectionObserverEntryInit intersectionObserverEntryInit),
+ Exposed=Window]
 interface IntersectionObserverEntry {
 	readonly attribute DOMHighResTimeStamp time;
 	readonly attribute DOMRectReadOnly? rootBounds;


### PR DESCRIPTION
Required after heycam/webidl#423 and heycam/webidl#750. (Found from web-platform-tests/wpt#18382)

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=180469)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=792432 https://bugs.chromium.org/p/chromium/issues/detail?id=948139)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1423562 https://bugzilla.mozilla.org/show_bug.cgi?id=1562680)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/IntersectionObserver/pull/382.html" title="Last updated on Aug 23, 2019, 8:13 AM UTC (38999c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/382/d3eece4...saschanaz:38999c1.html" title="Last updated on Aug 23, 2019, 8:13 AM UTC (38999c1)">Diff</a>