### PR TITLE
Old polyfill.io link no longer works

### DIFF
--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -106,11 +106,7 @@ This polyfill also does not support the [proposed v2 additions](https://github.c
 
 The polyfill has been tested and known to work in the latest version of all browsers.
 
-Legacy support is also possible in very old browsers by including a shim for ES5 as well as the `window.getComputedStyle` method. The easiest way to load the IntersectionObserver polyfill and have it work in the widest range of browsers is via [polyfill.io](https://cdn.polyfill.io/v3/), which will automatically include dependencies where necessary:
-
-```html
-<script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
-```
+Legacy support is also possible in very old browsers by including a shim for ES5 as well as the `window.getComputedStyle` method.
 
 With these polyfills, `IntersectionObserver` has been tested an known to work in the following browsers:
 


### PR DESCRIPTION
https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver does not contain anything anymore

Closes #???

The following tasks have been completed:

 * [x] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [x] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
