### PR TITLE
Polyfill: support same-origin iframe targets

### DIFF
--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -98,9 +98,7 @@ This is recommended in cases where the DOM will update frequently but you know t
 
 ## Limitations
 
-This polyfill does not attempt to report intersections across same-origin `iframe` boundaries. While supporting same-origin iframes is technically possible, it would drastically reduce performance. Since most `iframe` usage on the web is cross-origin, this polyfill chooses to optimize for performantly handling the most common use cases. (Note: neither this polyfill nor native implementations support reporting intersections across cross-origin `iframe` boundaries.)
-
-This polyfill also does not support the [proposed v2 additions](https://github.com/szager-chromium/IntersectionObserver/blob/v2/explainer.md), as these features are not currently possible to do with JavaScript and existing web APIs.
+This polyfill does not support the [proposed v2 additions](https://github.com/szager-chromium/IntersectionObserver/blob/v2/explainer.md), as these features are not currently possible to do with JavaScript and existing web APIs.
 
 ## Browser support
 

--- a/polyfill/intersection-observer-test.html
+++ b/polyfill/intersection-observer-test.html
@@ -27,6 +27,14 @@ Licensed under the W3C SOFTWARE AND DOCUMENT NOTICE AND LICENSE.
   <!-- Setup -->
   <script>mocha.setup({ui:'bdd'});</script>
 
+  <!-- Force polyfill. -->
+  <script>
+    if (false) {
+      delete window.IntersectionObserver;
+      delete window.IntersectionObserverEntry;
+    }
+  </script>
+
   <!-- Script under test -->
   <script src="intersection-observer.js"></script>
 

--- a/polyfill/intersection-observer-test.html
+++ b/polyfill/intersection-observer-test.html
@@ -27,13 +27,12 @@ Licensed under the W3C SOFTWARE AND DOCUMENT NOTICE AND LICENSE.
   <!-- Setup -->
   <script>mocha.setup({ui:'bdd'});</script>
 
-  <!-- Force polyfill. -->
+  <!-- Uncomment this script to force the polyfill installation
   <script>
-    if (false) {
-      delete window.IntersectionObserver;
-      delete window.IntersectionObserverEntry;
-    }
+    delete window.IntersectionObserver;
+    delete window.IntersectionObserverEntry;
   </script>
+  -->
 
   <!-- Script under test -->
   <script src="intersection-observer.js"></script>

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -953,18 +953,19 @@ describe('IntersectionObserver', function() {
       iframe.style.top = '0px';
       iframe.style.width = '100px';
       iframe.style.height = '200px';
-      iframe.srcdoc =
-        '<!DOCTYPE html><html><body>' +
-        '<style>' +
-        'body {margin: 0}' +
-        ' .target {height: 200px; margin-bottom: 2px; background: blue;}' +
-        '</style>';
       iframe.onerror = function() {
         done(new Error('iframe initialization failed'));
       };
       iframe.onload = function() {
         iframeWin = iframe.contentWindow;
         iframeDoc = iframeWin.document;
+        iframeDoc.open();
+        iframeDoc.write('<!DOCTYPE html><html><body>');
+        iframeDoc.write('<style>');
+        iframeDoc.write('body {margin: 0}');
+        iframeDoc.write('.target {height: 200px; margin-bottom: 2px; background: blue;}');
+        iframeDoc.write('</style>');
+        iframeDoc.close();
 
         function createTarget(id, bg) {
           var target = iframeDoc.createElement('div');
@@ -978,6 +979,7 @@ describe('IntersectionObserver', function() {
         iframeTargetEl2 = createTarget('target2', 'green');
         done();
       };
+      iframe.src = 'about:blank';
       rootEl.appendChild(iframe);
     });
 

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -941,6 +941,652 @@ describe('IntersectionObserver', function() {
 
   });
 
+  describe('same-origin iframe', function() {
+    var iframe, win, doc;
+    var iframeTargetEl1, iframeTargetEl2;
+
+    beforeEach(function() {
+      iframe = document.createElement('iframe');
+      iframe.setAttribute('frameborder', '0');
+      iframe.setAttribute('scrolling', 'yes');
+      iframe.style.position = 'fixed';
+      iframe.style.top = '0px';
+      iframe.style.width = '100px';
+      iframe.style.height = '200px';
+      iframe.srcdoc =
+        '<!DOCTYPE html><html><body>' +
+        '<style>' +
+        'body {margin: 0}' +
+        ' .target {height: 200px; margin-bottom: 2px; background: blue;}' +
+        '</style>';
+      return new Promise(function(resolve, reject) {
+        iframe.onload = resolve;
+        iframe.onerror = reject;
+        // Clear out rootEl and use iframe.
+        rootEl.appendChild(iframe);
+      }).then(function() {
+        iframeWin = iframe.contentWindow;
+        iframeDoc = iframeWin.document;
+      }).then(function() {
+        function createTarget(id, bg) {
+          var target = iframeDoc.createElement('div');
+          target.id = id;
+          target.className = 'target';
+          target.style.background = bg;
+          iframeDoc.body.appendChild(target);
+          return target;
+        }
+        iframeTargetEl1 = createTarget('target1', 'blue');
+        iframeTargetEl2 = createTarget('target2', 'green');
+      });
+    });
+
+    afterEach(function() {
+      rootEl.removeChild(iframe);
+    });
+
+    function rect(r) {
+      return {
+        top: r.top,
+        left: r.left,
+        width: r.width != null ? r.width : r.right - r.left,
+        height: r.height != null ? r.height : r.bottom - r.top,
+        right: r.right != null ? r.right : r.left + r.width,
+        bottom: r.bottom != null ? r.bottom : r.top + r.height
+      };
+    }
+
+    function getRootRect(doc) {
+      var html = doc.documentElement;
+      var body = doc.body;
+      return rect({
+        top: 0,
+        left: 0,
+        right: html.clientWidth || body.clientWidth,
+        width: html.clientWidth || body.clientWidth,
+        bottom: html.clientHeight || body.clientHeight,
+        height: html.clientHeight || body.clientHeight
+      });
+    }
+
+    it('iframe targets do not intersect with a top root element', function(done) {
+      var io = new IntersectionObserver(function(unsortedRecords) {
+        var records = sortRecords(unsortedRecords);
+        expect(records.length).to.be(2);
+        expect(records[0].isIntersecting).to.be(false);
+        expect(records[1].isIntersecting).to.be(false);
+        done();
+        io.disconnect();
+      }, {root: rootEl});
+      io.observe(iframeTargetEl1);
+      io.observe(iframeTargetEl2);
+    });
+
+    it('triggers for all targets in top-level root', function(done) {
+      var io = new IntersectionObserver(function(unsortedRecords) {
+        var records = sortRecords(unsortedRecords);
+        expect(records.length).to.be(2);
+        expect(records[0].isIntersecting).to.be(true);
+        expect(records[0].intersectionRatio).to.be(1);
+        expect(records[1].isIntersecting).to.be(false);
+        expect(records[1].intersectionRatio).to.be(0);
+
+        // The rootBounds is for the document's root.
+        expect(records[0].rootBounds.height).to.be(innerHeight);
+
+        done();
+        io.disconnect();
+      });
+      io.observe(iframeTargetEl1);
+      io.observe(iframeTargetEl2);
+    });
+
+    it('triggers for all targets in iframe-level root', function(done) {
+      var io = new IntersectionObserver(function(unsortedRecords) {
+        var records = sortRecords(unsortedRecords);
+        expect(records.length).to.be(2);
+        expect(records[0].intersectionRatio).to.be(1);
+        expect(records[1].intersectionRatio).to.be(1);
+
+        // The rootBounds is for the document's root.
+        expect(rect(records[0].rootBounds)).
+          to.eql(rect(iframeDoc.body.getBoundingClientRect()));
+
+        done();
+        io.disconnect();
+      }, {root: iframeDoc.body});
+      io.observe(iframeTargetEl1);
+      io.observe(iframeTargetEl2);
+    });
+
+    it('calculates rects for a fully visible frame', function(done) {
+      iframe.style.top = '0px';
+      iframe.style.height = '300px';
+      var io = new IntersectionObserver(function(unsortedRecords) {
+        var records = sortRecords(unsortedRecords);
+        expect(records.length).to.be(2);
+        expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
+        expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
+
+        // The target1 is fully visible.
+        var clientRect1 = rect({
+          top: 0,
+          left: 0,
+          width: 100,
+          height: 200
+        });
+        expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
+        expect(rect(records[0].intersectionRect)).to.eql(clientRect1);
+        expect(records[0].isIntersecting).to.be(true);
+        expect(records[0].intersectionRatio).to.be(1);
+
+        // The target2 is partially visible.
+        var clientRect2 = rect({
+          top: 202,
+          left: 0,
+          width: 100,
+          height: 200
+        });
+        var intersectRect2 = rect({
+          top: 202,
+          left: 0,
+          width: 100,
+          // The bottom is clipped off.
+          bottom: 300
+        });
+        expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
+        expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
+        expect(records[1].isIntersecting).to.be(true);
+        expect(records[1].intersectionRatio).to.be.within(0.48, 0.5); // ~0.5
+
+        done();
+        io.disconnect();
+      });
+      io.observe(iframeTargetEl1);
+      io.observe(iframeTargetEl2);
+    });
+
+    it('calculates rects for a fully visible and offset frame', function(done) {
+      iframe.style.top = '10px';
+      iframe.style.height = '300px';
+      var io = new IntersectionObserver(function(unsortedRecords) {
+        var records = sortRecords(unsortedRecords);
+        expect(records.length).to.be(2);
+        expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
+        expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
+
+        // The target1 is fully visible.
+        var clientRect1 = rect({
+          top: 0,
+          left: 0,
+          width: 100,
+          height: 200
+        });
+        expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
+        expect(rect(records[0].intersectionRect)).to.eql(clientRect1);
+        expect(records[0].isIntersecting).to.be(true);
+        expect(records[0].intersectionRatio).to.be(1);
+
+        // The target2 is partially visible.
+        var clientRect2 = rect({
+          top: 202,
+          left: 0,
+          width: 100,
+          height: 200
+        });
+        var intersectRect2 = rect({
+          top: 202,
+          left: 0,
+          width: 100,
+          // The bottom is clipped off.
+          bottom: 300
+        });
+        expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
+        expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
+        expect(records[1].isIntersecting).to.be(true);
+        expect(records[1].intersectionRatio).to.be.within(0.48, 0.5); // ~0.5
+
+        done();
+        io.disconnect();
+      });
+      io.observe(iframeTargetEl1);
+      io.observe(iframeTargetEl2);
+    });
+
+    it('calculates rects for a clipped frame on top', function(done) {
+      iframe.style.top = '-10px';
+      iframe.style.height = '300px';
+      var io = new IntersectionObserver(function(unsortedRecords) {
+        var records = sortRecords(unsortedRecords);
+        expect(records.length).to.be(2);
+        expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
+        expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
+
+        // The target1 is clipped at the top by the iframe's clipping.
+        var clientRect1 = rect({
+          top: 0,
+          left: 0,
+          width: 100,
+          height: 200
+        });
+        var intersectRect1 = rect({
+          left: 0,
+          width: 100,
+          // Top is clipped.
+          top: 10,
+          height: 200 - 10
+        });
+        expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
+        expect(rect(records[0].intersectionRect)).to.eql(intersectRect1);
+        expect(records[0].isIntersecting).to.be(true);
+        expect(records[0].intersectionRatio).to.within(0.94, 0.96); // ~0.95
+
+        // The target2 is partially visible.
+        var clientRect2 = rect({
+          top: 202,
+          left: 0,
+          width: 100,
+          height: 200
+        });
+        var intersectRect2 = rect({
+          top: 202,
+          left: 0,
+          width: 100,
+          // The bottom is clipped off.
+          bottom: 300
+        });
+        expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
+        expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
+        expect(records[1].isIntersecting).to.be(true);
+        expect(records[1].intersectionRatio).to.be.within(0.48, 0.5); // ~0.49
+
+        done();
+        io.disconnect();
+      });
+      io.observe(iframeTargetEl1);
+      io.observe(iframeTargetEl2);
+    });
+
+    it('calculates rects for a clipped frame on bottom', function(done) {
+      iframe.style.top = 'auto';
+      iframe.style.bottom = '-10px';
+      iframe.style.height = '300px';
+      var io = new IntersectionObserver(function(unsortedRecords) {
+        var records = sortRecords(unsortedRecords);
+        expect(records.length).to.be(2);
+        expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
+        expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
+
+        // The target1 is clipped at the top by the iframe's clipping.
+        var clientRect1 = rect({
+          top: 0,
+          left: 0,
+          width: 100,
+          height: 200
+        });
+        expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
+        expect(rect(records[0].intersectionRect)).to.eql(clientRect1);
+        expect(records[0].isIntersecting).to.be(true);
+        expect(records[0].intersectionRatio).to.be(1);
+
+        // The target2 is partially visible.
+        var clientRect2 = rect({
+          top: 202,
+          left: 0,
+          width: 100,
+          height: 200
+        });
+        var intersectRect2 = rect({
+          top: 202,
+          left: 0,
+          width: 100,
+          // The bottom is clipped off.
+          bottom: 300 - 10
+        });
+        expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
+        expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
+        expect(records[1].isIntersecting).to.be(true);
+        expect(records[1].intersectionRatio).to.be.within(0.43, 0.45); // ~0.44
+
+        done();
+        io.disconnect();
+      });
+      io.observe(iframeTargetEl1);
+      io.observe(iframeTargetEl2);
+    });
+
+    it('calculates rects for a fully visible frame and scrolled', function(done) {
+      iframe.style.top = '0px';
+      iframe.style.height = '300px';
+      iframeWin.scrollTo(0, 10);
+      var io = new IntersectionObserver(function(unsortedRecords) {
+        var records = sortRecords(unsortedRecords);
+        expect(records.length).to.be(2);
+        expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
+        expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
+
+        // The target1 is fully visible.
+        var clientRect1 = rect({
+          top: -10,
+          left: 0,
+          width: 100,
+          height: 200
+        });
+        var intersectRect1 = rect({
+          top: 0,
+          left: 0,
+          width: 100,
+          // Height is only for the visible area.
+          height: 200 - 10
+        });
+        expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
+        expect(rect(records[0].intersectionRect)).to.eql(intersectRect1);
+        expect(records[0].isIntersecting).to.be(true);
+        expect(records[0].intersectionRatio).to.within(0.94, 0.96); // ~0.95
+
+        // The target2 is partially visible.
+        var clientRect2 = rect({
+          top: 202 - 10,
+          left: 0,
+          width: 100,
+          height: 200
+        });
+        var intersectRect2 = rect({
+          top: 202 - 10,
+          left: 0,
+          width: 100,
+          // The bottom is clipped off.
+          bottom: 300
+        });
+        expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
+        expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
+        expect(records[1].isIntersecting).to.be(true);
+        expect(records[1].intersectionRatio).to.be.within(0.53, 0.55); // ~0.54
+
+        done();
+        io.disconnect();
+      });
+      io.observe(iframeTargetEl1);
+      io.observe(iframeTargetEl2);
+    });
+
+    it('calculates rects for a clipped frame on top and scrolled', function(done) {
+      iframe.style.top = '-10px';
+      iframe.style.height = '300px';
+      iframeWin.scrollTo(0, 10);
+      var io = new IntersectionObserver(function(unsortedRecords) {
+        var records = sortRecords(unsortedRecords);
+        expect(records.length).to.be(2);
+        expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
+        expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
+
+        // The target1 is clipped at the top by the iframe's clipping.
+        var clientRect1 = rect({
+          top: -10,
+          left: 0,
+          width: 100,
+          height: 200
+        });
+        var intersectRect1 = rect({
+          left: 0,
+          width: 100,
+          // Top is clipped.
+          top: 10,
+          // The height is less by both: offset and scroll.
+          height: 200 - 10 - 10
+        });
+        expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
+        expect(rect(records[0].intersectionRect)).to.eql(intersectRect1);
+        expect(records[0].isIntersecting).to.be(true);
+        expect(records[0].intersectionRatio).to.within(0.89, 0.91); // ~0.9
+
+        // The target2 is partially visible.
+        var clientRect2 = rect({
+          top: 202 - 10,
+          left: 0,
+          width: 100,
+          height: 200
+        });
+        var intersectRect2 = rect({
+          top: 202 - 10,
+          left: 0,
+          width: 100,
+          // The bottom is clipped off.
+          bottom: 300
+        });
+        expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
+        expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
+        expect(records[1].isIntersecting).to.be(true);
+        expect(records[1].intersectionRatio).to.be.within(0.53, 0.55); // ~0.54
+
+        done();
+        io.disconnect();
+      });
+      io.observe(iframeTargetEl1);
+      io.observe(iframeTargetEl2);
+    });
+
+    it('handles style changes', function(done) {
+      var spy = sinon.spy();
+
+      // When first element becomes invisible, the second element will show.
+      // And in reverse: when the first element becomes visible again, the
+      // second element will disappear.
+      var io = new IntersectionObserver(spy);
+      io.observe(iframeTargetEl1);
+      io.observe(iframeTargetEl2);
+
+      runSequence([
+        function(done) {
+          setTimeout(function() {
+            expect(spy.callCount).to.be(1);
+            var records = sortRecords(spy.lastCall.args[0]);
+            expect(records.length).to.be(2);
+            expect(records[0].intersectionRatio).to.be(1);
+            expect(records[0].isIntersecting).to.be(true);
+            expect(records[1].intersectionRatio).to.be(0);
+            expect(records[1].isIntersecting).to.be(false);
+            done();
+          }, ASYNC_TIMEOUT);
+        },
+        function(done) {
+          iframeTargetEl1.style.display = 'none';
+          setTimeout(function() {
+            expect(spy.callCount).to.be(2);
+            var records = sortRecords(spy.lastCall.args[0]);
+            expect(records.length).to.be(2);
+            expect(records[0].intersectionRatio).to.be(0);
+            expect(records[0].isIntersecting).to.be(false);
+            expect(records[1].intersectionRatio).to.be(1);
+            expect(records[1].isIntersecting).to.be(true);
+            done();
+          }, ASYNC_TIMEOUT);
+        },
+        function(done) {
+          iframeTargetEl1.style.display = '';
+          setTimeout(function() {
+            expect(spy.callCount).to.be(3);
+            var records = sortRecords(spy.lastCall.args[0]);
+            expect(records.length).to.be(2);
+            expect(records[0].intersectionRatio).to.be(1);
+            expect(records[0].isIntersecting).to.be(true);
+            expect(records[1].intersectionRatio).to.be(0);
+            expect(records[1].isIntersecting).to.be(false);
+            done();
+          }, ASYNC_TIMEOUT);
+        },
+        function(done) {
+          io.disconnect();
+          done();
+        }
+      ], done);
+    });
+
+    it('handles scroll changes', function(done) {
+      var spy = sinon.spy();
+
+      // Scrolling to the middle of the iframe shows the second box and
+      // hides the first.
+      var io = new IntersectionObserver(spy);
+      io.observe(iframeTargetEl1);
+      io.observe(iframeTargetEl2);
+
+      runSequence([
+        function(done) {
+          setTimeout(function() {
+            expect(spy.callCount).to.be(1);
+            var records = sortRecords(spy.lastCall.args[0]);
+            expect(records.length).to.be(2);
+            expect(records[0].intersectionRatio).to.be(1);
+            expect(records[0].isIntersecting).to.be(true);
+            expect(records[1].intersectionRatio).to.be(0);
+            expect(records[1].isIntersecting).to.be(false);
+            done();
+          }, ASYNC_TIMEOUT);
+        },
+        function(done) {
+          iframeWin.scrollTo(0, 202);
+          setTimeout(function() {
+            expect(spy.callCount).to.be(2);
+            var records = sortRecords(spy.lastCall.args[0]);
+            expect(records.length).to.be(2);
+            expect(records[0].intersectionRatio).to.be(0);
+            expect(records[0].isIntersecting).to.be(false);
+            expect(records[1].intersectionRatio).to.be(1);
+            expect(records[1].isIntersecting).to.be(true);
+            done();
+          }, ASYNC_TIMEOUT);
+        },
+        function(done) {
+          iframeWin.scrollTo(0, 0);
+          setTimeout(function() {
+            expect(spy.callCount).to.be(3);
+            var records = sortRecords(spy.lastCall.args[0]);
+            expect(records.length).to.be(2);
+            expect(records[0].intersectionRatio).to.be(1);
+            expect(records[0].isIntersecting).to.be(true);
+            expect(records[1].intersectionRatio).to.be(0);
+            expect(records[1].isIntersecting).to.be(false);
+            done();
+          }, ASYNC_TIMEOUT);
+        },
+        function(done) {
+          io.disconnect();
+          done();
+        }
+      ], done);
+    });
+
+    it('handles iframe changes', function(done) {
+      var spy = sinon.spy();
+
+      // Iframe goes off screen and returns.
+      var io = new IntersectionObserver(spy);
+      io.observe(iframeTargetEl1);
+      io.observe(iframeTargetEl2);
+
+      runSequence([
+        function(done) {
+          setTimeout(function() {
+            expect(spy.callCount).to.be(1);
+            var records = sortRecords(spy.lastCall.args[0]);
+            expect(records.length).to.be(2);
+            expect(records[0].intersectionRatio).to.be(1);
+            expect(records[0].isIntersecting).to.be(true);
+            expect(records[1].intersectionRatio).to.be(0);
+            expect(records[1].isIntersecting).to.be(false);
+            // Top-level bounds.
+            expect(records[0].rootBounds.height).to.be(innerHeight);
+            expect(records[0].intersectionRect.height).to.be(200);
+            done();
+          }, ASYNC_TIMEOUT);
+        },
+        function(done) {
+          // Completely off screen.
+          iframe.style.top = '-202px';
+          setTimeout(function() {
+            expect(spy.callCount).to.be(2);
+            var records = sortRecords(spy.lastCall.args[0]);
+            expect(records.length).to.be(1);
+            expect(records[0].intersectionRatio).to.be(0);
+            expect(records[0].isIntersecting).to.be(false);
+            // Top-level bounds.
+            expect(records[0].rootBounds.height).to.be(innerHeight);
+            expect(records[0].intersectionRect.height).to.be(0);
+            done();
+          }, ASYNC_TIMEOUT);
+        },
+        function(done) {
+          // Partially returns.
+          iframe.style.top = '-100px';
+          setTimeout(function() {
+            expect(spy.callCount).to.be(3);
+            var records = sortRecords(spy.lastCall.args[0]);
+            expect(records.length).to.be(1);
+            expect(records[0].intersectionRatio).to.be.within(0.45, 0.55);
+            expect(records[0].isIntersecting).to.be(true);
+            // Top-level bounds.
+            expect(records[0].rootBounds.height).to.be(innerHeight);
+            expect(records[0].intersectionRect.height / 200).to.be.within(0.45, 0.55);
+            done();
+          }, ASYNC_TIMEOUT);
+        },
+        function(done) {
+          io.disconnect();
+          done();
+        }
+      ], done);
+    });
+
+    it('continues to monitor until the last target unobserved', function(done) {
+      var spy = sinon.spy();
+
+      // Iframe goes off screen and returns.
+      var io = new IntersectionObserver(spy);
+      io.observe(target1);
+      io.observe(iframeTargetEl1);
+      io.observe(iframeTargetEl2);
+
+      runSequence([
+        function(done) {
+          setTimeout(function() {
+            expect(spy.callCount).to.be(1);
+            expect(spy.lastCall.args[0].length).to.be(3);
+
+            // Unobserve one from the main context and one from iframe.
+            io.unobserve(target1);
+            io.unobserve(iframeTargetEl2);
+
+            done();
+          }, ASYNC_TIMEOUT);
+        },
+        function(done) {
+          // Completely off screen.
+          iframe.style.top = '-202px';
+          setTimeout(function() {
+            expect(spy.callCount).to.be(2);
+            expect(spy.lastCall.args[0].length).to.be(1);
+
+            io.unobserve(iframeTargetEl1);
+
+            done();
+          }, ASYNC_TIMEOUT);
+        },
+        function(done) {
+          // Partially returns.
+          iframe.style.top = '-100px';
+          setTimeout(function() {
+            expect(spy.callCount).to.be(2);
+            done();
+          }, ASYNC_TIMEOUT);
+        },
+        function(done) {
+          io.disconnect();
+          done();
+        }
+      ], done);
+    });
+  });
 });
 
 

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -957,6 +957,7 @@ describe('IntersectionObserver', function() {
         done(new Error('iframe initialization failed'));
       };
       iframe.onload = function() {
+        iframe.onload = null;
         iframeWin = iframe.contentWindow;
         iframeDoc = iframeWin.document;
         iframeDoc.open();

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -945,7 +945,7 @@ describe('IntersectionObserver', function() {
     var iframe, win, doc;
     var iframeTargetEl1, iframeTargetEl2;
 
-    beforeEach(function() {
+    beforeEach(function(done) {
       iframe = document.createElement('iframe');
       iframe.setAttribute('frameborder', '0');
       iframe.setAttribute('scrolling', 'yes');
@@ -959,15 +959,13 @@ describe('IntersectionObserver', function() {
         'body {margin: 0}' +
         ' .target {height: 200px; margin-bottom: 2px; background: blue;}' +
         '</style>';
-      return new Promise(function(resolve, reject) {
-        iframe.onload = resolve;
-        iframe.onerror = reject;
-        // Clear out rootEl and use iframe.
-        rootEl.appendChild(iframe);
-      }).then(function() {
+      iframe.onerror = function() {
+        done(new Error('iframe initialization failed'));
+      };
+      iframe.onload = function() {
         iframeWin = iframe.contentWindow;
         iframeDoc = iframeWin.document;
-      }).then(function() {
+
         function createTarget(id, bg) {
           var target = iframeDoc.createElement('div');
           target.id = id;
@@ -978,7 +976,9 @@ describe('IntersectionObserver', function() {
         }
         iframeTargetEl1 = createTarget('target1', 'blue');
         iframeTargetEl2 = createTarget('target2', 'green');
-      });
+        done();
+      };
+      rootEl.appendChild(iframe);
     });
 
     afterEach(function() {

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -944,6 +944,7 @@ describe('IntersectionObserver', function() {
   describe('same-origin iframe', function() {
     var iframe, win, doc;
     var iframeTargetEl1, iframeTargetEl2;
+    var bodyWidth;
 
     beforeEach(function(done) {
       iframe = document.createElement('iframe');
@@ -978,6 +979,7 @@ describe('IntersectionObserver', function() {
         }
         iframeTargetEl1 = createTarget('target1', 'blue');
         iframeTargetEl2 = createTarget('target2', 'green');
+        bodyWidth = iframeDoc.body.clientWidth;
         done();
       };
       iframe.src = 'about:blank';
@@ -1075,7 +1077,7 @@ describe('IntersectionObserver', function() {
         var clientRect1 = rect({
           top: 0,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           height: 200
         });
         expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
@@ -1087,13 +1089,13 @@ describe('IntersectionObserver', function() {
         var clientRect2 = rect({
           top: 202,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           height: 200
         });
         var intersectRect2 = rect({
           top: 202,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           // The bottom is clipped off.
           bottom: 300
         });
@@ -1122,7 +1124,7 @@ describe('IntersectionObserver', function() {
         var clientRect1 = rect({
           top: 0,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           height: 200
         });
         expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
@@ -1134,13 +1136,13 @@ describe('IntersectionObserver', function() {
         var clientRect2 = rect({
           top: 202,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           height: 200
         });
         var intersectRect2 = rect({
           top: 202,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           // The bottom is clipped off.
           bottom: 300
         });
@@ -1169,12 +1171,12 @@ describe('IntersectionObserver', function() {
         var clientRect1 = rect({
           top: 0,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           height: 200
         });
         var intersectRect1 = rect({
           left: 0,
-          width: 100,
+          width: bodyWidth,
           // Top is clipped.
           top: 10,
           height: 200 - 10
@@ -1188,13 +1190,13 @@ describe('IntersectionObserver', function() {
         var clientRect2 = rect({
           top: 202,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           height: 200
         });
         var intersectRect2 = rect({
           top: 202,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           // The bottom is clipped off.
           bottom: 300
         });
@@ -1224,7 +1226,7 @@ describe('IntersectionObserver', function() {
         var clientRect1 = rect({
           top: 0,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           height: 200
         });
         expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
@@ -1236,13 +1238,13 @@ describe('IntersectionObserver', function() {
         var clientRect2 = rect({
           top: 202,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           height: 200
         });
         var intersectRect2 = rect({
           top: 202,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           // The bottom is clipped off.
           bottom: 300 - 10
         });
@@ -1272,13 +1274,13 @@ describe('IntersectionObserver', function() {
         var clientRect1 = rect({
           top: -10,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           height: 200
         });
         var intersectRect1 = rect({
           top: 0,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           // Height is only for the visible area.
           height: 200 - 10
         });
@@ -1291,13 +1293,13 @@ describe('IntersectionObserver', function() {
         var clientRect2 = rect({
           top: 202 - 10,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           height: 200
         });
         var intersectRect2 = rect({
           top: 202 - 10,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           // The bottom is clipped off.
           bottom: 300
         });
@@ -1327,12 +1329,12 @@ describe('IntersectionObserver', function() {
         var clientRect1 = rect({
           top: -10,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           height: 200
         });
         var intersectRect1 = rect({
           left: 0,
-          width: 100,
+          width: bodyWidth,
           // Top is clipped.
           top: 10,
           // The height is less by both: offset and scroll.
@@ -1347,13 +1349,13 @@ describe('IntersectionObserver', function() {
         var clientRect2 = rect({
           top: 202 - 10,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           height: 200
         });
         var intersectRect2 = rect({
           top: 202 - 10,
           left: 0,
-          width: 100,
+          width: bodyWidth,
           // The bottom is clipped off.
           bottom: 300
         });

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -862,7 +862,7 @@ function getParentNode(node) {
 
 
 /**
- * Returns the embedding framem element, if any.
+ * Returns the embedding frame element, if any.
  * @param {!Document} doc
  * @return {!Element}
  */

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -266,7 +266,7 @@ IntersectionObserver.prototype._parseRootMargin = function(opt_rootMargin) {
 /**
  * Starts polling for intersection changes if the polling is not already
  * happening, and if the page's visibility state is visible.
- * @param {!Window} doc
+ * @param {!Document} doc
  * @private
  */
 IntersectionObserver.prototype._monitorIntersections = function(doc) {
@@ -281,20 +281,18 @@ IntersectionObserver.prototype._monitorIntersections = function(doc) {
   }
 
   // Private state for monitoring.
-  var pollInterval = this.POLL_INTERVAL;
-  var useMutationObserver = this.USE_MUTATION_OBSERVER;
   var callback = this._checkForIntersections;
   var monitoringInterval = null;
   var domObserver = null;
 
   // If a poll interval is set, use polling instead of listening to
   // resize and scroll events or DOM mutations.
-  if (pollInterval) {
-    monitoringInterval = win.setInterval(callback, pollInterval);
+  if (this.POLL_INTERVAL) {
+    monitoringInterval = win.setInterval(callback, this.POLL_INTERVAL);
   } else {
     addEvent(win, 'resize', callback, true);
     addEvent(doc, 'scroll', callback, true);
-    if (useMutationObserver && 'MutationObserver' in win) {
+    if (this.USE_MUTATION_OBSERVER && 'MutationObserver' in win) {
       domObserver = new win.MutationObserver(callback);
       domObserver.observe(doc, {
         attributes: true,
@@ -844,7 +842,7 @@ function containsDeep(parent, child) {
 function getParentNode(node) {
   var parent = node.parentNode;
 
-  if (node.nodeType == 9) {
+  if (node.nodeType == /* DOCUMENT */ 9 && node != document) {
     // If this node is a document node, look for the embedding frame.
     return getFrameElement(node);
   }

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -346,8 +346,8 @@ IntersectionObserver.prototype._unmonitorIntersections = function(doc) {
   var rootDoc = (this.root && this.root.ownerDocument || document);
 
   // Check if any dependent targets are still remaining.
-  var dependentTargets =
-      this._observationTargets.filter(function(item) {
+  var hasDependentTargets =
+      this._observationTargets.some(function(item) {
         var itemDoc = item.element.ownerDocument;
         // Target is in this context.
         if (itemDoc == doc) {
@@ -363,7 +363,7 @@ IntersectionObserver.prototype._unmonitorIntersections = function(doc) {
         }
         return false;
       });
-  if (dependentTargets.length > 0) {
+  if (hasDependentTargets) {
     return;
   }
 
@@ -389,7 +389,7 @@ IntersectionObserver.prototype._unmonitorIntersections = function(doc) {
  * @private
  */
 IntersectionObserver.prototype._unmonitorAllIntersections = function() {
-  var unsubscribes = [].concat(this._monitoringUnsubscribes);
+  var unsubscribes = this._monitoringUnsubscribes.slice(0);
   this._monitoringDocuments.length = 0;
   this._monitoringUnsubscribes.length = 0;
   for (var i = 0; i < unsubscribes.length; i++) {
@@ -795,7 +795,7 @@ function getEmptyRect() {
 
 
 /**
- * Inverts the intersection and bonding rect from the parent (frame) BCR to
+ * Inverts the intersection and bounding rect from the parent (frame) BCR to
  * the local BCR space.
  * @param {Object} parentBoundingRect The parent's bound client rect.
  * @param {Object} parentIntersectionRect The parent's own intersection rect.

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -118,6 +118,11 @@ function IntersectionObserver(callback, opt_options) {
   this.rootMargin = this._rootMarginValues.map(function(margin) {
     return margin.value + margin.unit;
   }).join(' ');
+
+  /** @private @const {!Array<!Document>} */
+  this._monitoringDocuments = [];
+  /** @private @const {!Array<function()>} */
+  this._monitoringUnsubscribes = [];
 }
 
 
@@ -162,7 +167,7 @@ IntersectionObserver.prototype.observe = function(target) {
 
   this._registerInstance();
   this._observationTargets.push({element: target, entry: null});
-  this._monitorIntersections();
+  this._monitorIntersections(target.ownerDocument);
   this._checkForIntersections();
 };
 
@@ -174,11 +179,10 @@ IntersectionObserver.prototype.observe = function(target) {
 IntersectionObserver.prototype.unobserve = function(target) {
   this._observationTargets =
       this._observationTargets.filter(function(item) {
-
-    return item.element != target;
-  });
-  if (!this._observationTargets.length) {
-    this._unmonitorIntersections();
+        return item.element != target;
+      });
+  this._unmonitorIntersections(target.ownerDocument);
+  if (this._observationTargets.length == 0) {
     this._unregisterInstance();
   }
 };
@@ -189,7 +193,7 @@ IntersectionObserver.prototype.unobserve = function(target) {
  */
 IntersectionObserver.prototype.disconnect = function() {
   this._observationTargets = [];
-  this._unmonitorIntersections();
+  this._unmonitorAllIntersections();
   this._unregisterInstance();
 };
 
@@ -262,31 +266,69 @@ IntersectionObserver.prototype._parseRootMargin = function(opt_rootMargin) {
 /**
  * Starts polling for intersection changes if the polling is not already
  * happening, and if the page's visibility state is visible.
+ * @param {!Window} doc
  * @private
  */
-IntersectionObserver.prototype._monitorIntersections = function() {
-  if (!this._monitoringIntersections) {
-    this._monitoringIntersections = true;
+IntersectionObserver.prototype._monitorIntersections = function(doc) {
+  var win = doc.defaultView;
+  if (!win) {
+    // Already destroyed.
+    return;
+  }
+  if (this._monitoringDocuments.indexOf(doc) != -1) {
+    // Already monitoring.
+    return;
+  }
 
-    // If a poll interval is set, use polling instead of listening to
-    // resize and scroll events or DOM mutations.
-    if (this.POLL_INTERVAL) {
-      this._monitoringInterval = setInterval(
-          this._checkForIntersections, this.POLL_INTERVAL);
+  // Private state for monitoring.
+  var pollInterval = this.POLL_INTERVAL;
+  var useMutationObserver = this.USE_MUTATION_OBSERVER;
+  var callback = this._checkForIntersections;
+  var monitoringInterval = null;
+  var domObserver = null;
+
+  // If a poll interval is set, use polling instead of listening to
+  // resize and scroll events or DOM mutations.
+  if (pollInterval) {
+    monitoringInterval = win.setInterval(callback, pollInterval);
+  } else {
+    addEvent(win, 'resize', callback, true);
+    addEvent(doc, 'scroll', callback, true);
+    if (useMutationObserver && 'MutationObserver' in win) {
+      domObserver = new win.MutationObserver(callback);
+      domObserver.observe(doc, {
+        attributes: true,
+        childList: true,
+        characterData: true,
+        subtree: true
+      });
     }
-    else {
-      addEvent(window, 'resize', this._checkForIntersections, true);
-      addEvent(document, 'scroll', this._checkForIntersections, true);
+  }
 
-      if (this.USE_MUTATION_OBSERVER && 'MutationObserver' in window) {
-        this._domObserver = new MutationObserver(this._checkForIntersections);
-        this._domObserver.observe(document, {
-          attributes: true,
-          childList: true,
-          characterData: true,
-          subtree: true
-        });
+  this._monitoringDocuments.push(doc);
+  this._monitoringUnsubscribes.push(function() {
+    // Get the window object again. When a friendly iframe is destroyed, it
+    // will be null.
+    var win = doc.defaultView;
+
+    if (win) {
+      if (monitoringInterval) {
+        win.clearInterval(monitoringInterval);
       }
+      removeEvent(win, 'resize', callback, true);
+    }
+
+    removeEvent(doc, 'scroll', callback, true);
+    if (domObserver) {
+      domObserver.disconnect();
+    }
+  });
+
+  // Also monitor the parent.
+  if (doc != (this.root && this.root.ownerDocument || document)) {
+    var frame = getFrameElement(doc);
+    if (frame) {
+      this._monitorIntersections(frame.ownerDocument);
     }
   }
 };
@@ -294,22 +336,66 @@ IntersectionObserver.prototype._monitorIntersections = function() {
 
 /**
  * Stops polling for intersection changes.
+ * @param {!Document} doc
  * @private
  */
-IntersectionObserver.prototype._unmonitorIntersections = function() {
-  if (this._monitoringIntersections) {
-    this._monitoringIntersections = false;
+IntersectionObserver.prototype._unmonitorIntersections = function(doc) {
+  var index = this._monitoringDocuments.indexOf(doc);
+  if (index == -1) {
+    return;
+  }
 
-    clearInterval(this._monitoringInterval);
-    this._monitoringInterval = null;
+  var rootDoc = (this.root && this.root.ownerDocument || document);
 
-    removeEvent(window, 'resize', this._checkForIntersections, true);
-    removeEvent(document, 'scroll', this._checkForIntersections, true);
+  // Check if any dependent targets are still remaining.
+  var dependentTargets =
+      this._observationTargets.filter(function(item) {
+        var itemDoc = item.element.ownerDocument;
+        // Target is in this context.
+        if (itemDoc == doc) {
+          return true;
+        }
+        // Target is nested in this context.
+        while (itemDoc && itemDoc != rootDoc) {
+          var frame = getFrameElement(itemDoc);
+          itemDoc = frame && frame.ownerDocument;
+          if (itemDoc == doc) {
+            return true;
+          }
+        }
+        return false;
+      });
+  if (dependentTargets.length > 0) {
+    return;
+  }
 
-    if (this._domObserver) {
-      this._domObserver.disconnect();
-      this._domObserver = null;
+  // Unsubscribe.
+  var unsubscribe = this._monitoringUnsubscribes[index];
+  this._monitoringDocuments.splice(index, 1);
+  this._monitoringUnsubscribes.splice(index, 1);
+  unsubscribe();
+
+  // Also unmonitor the parent.
+  if (doc != rootDoc) {
+    var frame = getFrameElement(doc);
+    if (frame) {
+      this._unmonitorIntersections(frame.ownerDocument);
     }
+  }
+};
+
+
+/**
+ * Stops polling for intersection changes.
+ * @param {!Document} doc
+ * @private
+ */
+IntersectionObserver.prototype._unmonitorAllIntersections = function() {
+  var unsubscribes = [].concat(this._monitoringUnsubscribes);
+  this._monitoringDocuments.length = 0;
+  this._monitoringUnsubscribes.length = 0;
+  for (var i = 0; i < unsubscribes.length; i++) {
+    unsubscribes[i]();
   }
 };
 
@@ -330,7 +416,7 @@ IntersectionObserver.prototype._checkForIntersections = function() {
     var rootContainsTarget = this._rootContainsTarget(target);
     var oldEntry = item.entry;
     var intersectionRect = rootIsInDom && rootContainsTarget &&
-        this._computeTargetAndRootIntersection(target, rootRect);
+        this._computeTargetAndRootIntersection(target, targetRect, rootRect);
 
     var newEntry = item.entry = new IntersectionObserverEntry({
       time: now(),
@@ -370,6 +456,7 @@ IntersectionObserver.prototype._checkForIntersections = function() {
  * TODO(philipwalton): at this time clip-path is not considered.
  * https://w3c.github.io/IntersectionObserver/#calculate-intersection-rect-algo
  * @param {Element} target The target DOM element
+ * @param {Object} targetRect The bounding rect of the target.
  * @param {Object} rootRect The bounding rect of the root after being
  *     expanded by the rootMargin value.
  * @return {?Object} The final intersection rect object or undefined if no
@@ -377,34 +464,49 @@ IntersectionObserver.prototype._checkForIntersections = function() {
  * @private
  */
 IntersectionObserver.prototype._computeTargetAndRootIntersection =
-    function(target, rootRect) {
-
+    function(target, targetRect, rootRect) {
   // If the element isn't displayed, an intersection can't happen.
   if (window.getComputedStyle(target).display == 'none') return;
 
-  var targetRect = getBoundingClientRect(target);
   var intersectionRect = targetRect;
   var parent = getParentNode(target);
   var atRoot = false;
 
-  while (!atRoot) {
+  while (!atRoot && parent) {
     var parentRect = null;
     var parentComputedStyle = parent.nodeType == 1 ?
         window.getComputedStyle(parent) : {};
 
     // If the parent isn't displayed, an intersection can't happen.
-    if (parentComputedStyle.display == 'none') return;
+    if (parentComputedStyle.display == 'none') return null;
 
-    if (parent == this.root || parent == document) {
+    if (parent == this.root || parent.nodeType == /* DOCUMENT */ 9) {
       atRoot = true;
-      parentRect = rootRect;
+      if (parent == this.root || parent == document) {
+        parentRect = rootRect;
+      } else {
+        // Check if there's a frame that can be navigated to.
+        var frame = getParentNode(parent);
+        var frameRect = frame && getBoundingClientRect(frame);
+        var frameIntersect =
+            frame &&
+            this._computeTargetAndRootIntersection(frame, frameRect, rootRect);
+        if (frameRect && frameIntersect) {
+          parent = frame;
+          parentRect = convertFromParentRect(frameRect, frameIntersect);
+        } else {
+          parent = null;
+          intersectionRect = null;
+        }
+      }
     } else {
       // If the element has a non-visible overflow, and it's not the <body>
       // or <html> element, update the intersection rect.
       // Note: <body> and <html> cannot be clipped to a rect that's not also
       // the document rect, so no need to compute a new intersection.
-      if (parent != document.body &&
-          parent != document.documentElement &&
+      var doc = parent.ownerDocument;
+      if (parent != doc.body &&
+          parent != doc.documentElement &&
           parentComputedStyle.overflow != 'visible') {
         parentRect = getBoundingClientRect(parent);
       }
@@ -414,10 +516,9 @@ IntersectionObserver.prototype._computeTargetAndRootIntersection =
     // calculate new intersection data.
     if (parentRect) {
       intersectionRect = computeRectIntersection(parentRect, intersectionRect);
-
-      if (!intersectionRect) break;
     }
-    parent = getParentNode(parent);
+    if (!intersectionRect) break;
+    parent = parent && getParentNode(parent);
   }
   return intersectionRect;
 };
@@ -526,7 +627,8 @@ IntersectionObserver.prototype._rootIsInDom = function() {
  * @private
  */
 IntersectionObserver.prototype._rootContainsTarget = function(target) {
-  return containsDeep(this.root || document, target);
+  return containsDeep(this.root || document, target) &&
+    (!this.root || this.root.ownerDocument == target.ownerDocument);
 };
 
 
@@ -641,7 +743,7 @@ function computeRectIntersection(rect1, rect2) {
     right: right,
     width: width,
     height: height
-  };
+  } || null;
 }
 
 
@@ -693,6 +795,28 @@ function getEmptyRect() {
   };
 }
 
+
+/**
+ * Inverts the intersection and bonding rect from the parent (frame) BCR to
+ * the local BCR space.
+ * @param {Object} parentBoundingRect The parent's bound client rect.
+ * @param {Object} parentIntersectionRect The parent's own intersection rect.
+ * @return {Object} The local root bounding rect for the parent's children.
+ */
+function convertFromParentRect(parentBoundingRect, parentIntersectionRect) {
+  var top = parentIntersectionRect.top - parentBoundingRect.top;
+  var left = parentIntersectionRect.left - parentBoundingRect.left;
+  return {
+    top: top,
+    left: left,
+    height: parentIntersectionRect.height,
+    width: parentIntersectionRect.width,
+    bottom: top + parentIntersectionRect.height,
+    right: left + parentIntersectionRect.width
+  };
+}
+
+
 /**
  * Checks to see if a parent element contains a child element (including inside
  * shadow DOM).
@@ -720,6 +844,11 @@ function containsDeep(parent, child) {
 function getParentNode(node) {
   var parent = node.parentNode;
 
+  if (node.nodeType == 9) {
+    // If this node is a document node, look for the embedding frame.
+    return getFrameElement(node);
+  }
+
   if (parent && parent.nodeType == 11 && parent.host) {
     // If the parent is a shadow root, return the host element.
     return parent.host;
@@ -731,6 +860,21 @@ function getParentNode(node) {
   }
 
   return parent;
+}
+
+
+/**
+ * Returns the embedding framem element, if any.
+ * @param {!Document} doc
+ * @return {!Element}
+ */
+function getFrameElement(doc) {
+  try {
+    return doc.defaultView && doc.defaultView.frameElement || null;
+  } catch (e) {
+    // Ignore the error.
+    return null;
+  }
 }
 
 

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intersection-observer",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A polyfill for IntersectionObserver",
   "main": "intersection-observer",
   "repository": {


### PR DESCRIPTION
The polyfill is updated to support observing targets in the same-origin iframes. This is already a spec'd behavior and only polyfill abilities are enhanced. See https://www.w3.org/TR/intersection-observer/#dom-intersectionobserver-rootmargin for more info.

Notably, the changes to do not polyfill the `IntersectionObserver` inside an iframe, but simply allow observing using the top-level context `IntersectionObserver`. The final interface binding can be done by manually:

```
iframe.contentWindow.IntersectionObserver = window.IntersectionObserver;
iframe.contentWindow.IntersectionObserverEntry = window.IntersectionObserverEntry;
```

In practice, however, I find that even when same-origin iframes are used, the root observer is used for them. The tests show this pattern.