### PR TITLE
Support 3p mode for the polyfill

### DIFF
--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -117,7 +117,7 @@ cross-origin iframe element. It can either use the this polyfill or any other
 approach. For each IntersectionObserverEntry for the iframe it will forward
 intersection data to the iframe via messaging.
 3. The iframe will load the polyfill and configure it by calling the
-`polyfillSetupCrossOriginUpdater()` method. It will call the provided callback
+`_setupCrossOriginUpdater()` method. It will call the provided callback
 whenever it receives the intersection data from the the parent via messaging.
 
 A hypothetical host code:
@@ -144,8 +144,8 @@ A hypothetical iframe code:
 
 ```javascript
 createMessagingChannel(parent, function(port) {
-  if (IntersectionObserver.polyfillSetupCrossOriginUpdater) {
-    var crossOriginUpdater = IntersectionObserver.polyfillSetupCrossOriginUpdater();
+  if (IntersectionObserver._setupCrossOriginUpdater) {
+    var crossOriginUpdater = IntersectionObserver._setupCrossOriginUpdater();
     port.onmessage = function(event) {
       crossOriginUpdater(
         deserialize(event.data.boundingClientRect),

--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -97,7 +97,7 @@ io.USE_MUTATION_OBSERVER = false;
 This is recommended in cases where the DOM will update frequently but you know those updates will have no affect on the position or your target elements.
 
 
-## IFRAME support
+## iframe support
 
 ### Same-origin iframes
 
@@ -113,12 +113,12 @@ The setup is as following:
 
 1. The host and iframe will establish a messaging channel.
 2. The host will setup its own IntersectionObserver instance for the
-cross-orgin iframe element. It can either use the this polyfill or any other
+cross-origin iframe element. It can either use the this polyfill or any other
 approach. For each IntersectionObserverEntry for the iframe it will forward
 intersection data to the iframe via messaging.
 3. The iframe will load the polyfill and configure it by calling the
 `polyfillSetupCrossOriginUpdater()` method. It will call the provided callback
-whenever it receives the intersection data from the the parent via messsaging.
+whenever it receives the intersection data from the the parent via messaging.
 
 A hypothetical host code:
 

--- a/polyfill/README.md
+++ b/polyfill/README.md
@@ -130,11 +130,15 @@ function forwardIntersectionToIframe(iframe) {
         boundingClientRect: serialize(boundingClientRect),
         intersectionRect: serialize(intersectionRect)
       });
-    });
+    }, {threshold: [0, 0.1, ..., 1]});
     io.observe(iframe);
   });
 }
 ```
+
+Notice that the host should provide a `threshold` argument for the desired
+level of precision. Otherwise, the iframe side may not update as frequently as
+desired.
 
 A hypothetical iframe code:
 

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -942,7 +942,7 @@ describe('IntersectionObserver', function() {
   });
 
   describe('iframe', function() {
-    var iframe, win, doc;
+    var iframe;
     var documentElement, body;
     var iframeTargetEl1, iframeTargetEl2;
     var bodyWidth;

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -1702,7 +1702,7 @@ describe('IntersectionObserver', function() {
           expect(rect(records[0].intersectionRect)).to.eql(rect({
             top: 0,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 300
           }));
           expect(records[0].isIntersecting).to.be(true);
@@ -1715,7 +1715,7 @@ describe('IntersectionObserver', function() {
           expect(rect(records[1].intersectionRect)).to.eql(rect({
             top: 0,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 300
           }));
           expect(records[1].isIntersecting).to.be(true);
@@ -1726,7 +1726,7 @@ describe('IntersectionObserver', function() {
           var clientRect1 = rect({
             top: 0,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 200
           });
           expect(rect(records[2].boundingClientRect)).to.eql(clientRect1);
@@ -1755,7 +1755,7 @@ describe('IntersectionObserver', function() {
           expect(rect(records[0].intersectionRect)).to.eql(rect({
             top: 0,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 300
           }));
           expect(records[0].isIntersecting).to.be(true);
@@ -1768,7 +1768,7 @@ describe('IntersectionObserver', function() {
           expect(rect(records[1].intersectionRect)).to.eql(rect({
             top: 0,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 300
           }));
           expect(records[1].isIntersecting).to.be(true);
@@ -1779,7 +1779,7 @@ describe('IntersectionObserver', function() {
           var clientRect1 = rect({
             top: 0,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 200
           });
           expect(rect(records[2].boundingClientRect)).to.eql(clientRect1);
@@ -1808,7 +1808,7 @@ describe('IntersectionObserver', function() {
           expect(rect(records[0].intersectionRect)).to.eql(rect({
             top: 10,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 300 - 10
           }));
           expect(records[0].isIntersecting).to.be(true);
@@ -1821,7 +1821,7 @@ describe('IntersectionObserver', function() {
           expect(rect(records[1].intersectionRect)).to.eql(rect({
             top: 10,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 300 - 10
           }));
           expect(records[1].isIntersecting).to.be(true);
@@ -1832,12 +1832,12 @@ describe('IntersectionObserver', function() {
           var clientRect1 = rect({
             top: 0,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 200
           });
           var intersectRect1 = rect({
             left: 0,
-            width: 100,
+            width: bodyWidth,
             // Top is clipped.
             top: 10,
             height: 200 - 10
@@ -1869,7 +1869,7 @@ describe('IntersectionObserver', function() {
           expect(rect(records[0].intersectionRect)).to.eql(rect({
             top: 0,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 300 - 10
           }));
           expect(records[0].isIntersecting).to.be(true);
@@ -1882,7 +1882,7 @@ describe('IntersectionObserver', function() {
           expect(rect(records[1].intersectionRect)).to.eql(rect({
             top: 0,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 300 - 10
           }));
           expect(records[1].isIntersecting).to.be(true);
@@ -1893,7 +1893,7 @@ describe('IntersectionObserver', function() {
           var clientRect1 = rect({
             top: 0,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 200
           });
           expect(rect(records[2].boundingClientRect)).to.eql(clientRect1);
@@ -1909,7 +1909,7 @@ describe('IntersectionObserver', function() {
         io.observe(iframeTargetEl1);
       });
 
-      it('calculates rects for a fully visible frame and scrolled', function(done) {
+      it('calculates rects for a fully visible and scrolled frame', function(done) {
         iframeWin.scrollTo(0, 10);
         var parentRect = rect({top: 0, left: 20, height: 300, width: 100});
         var io = createObserver(function(unsortedRecords) {
@@ -1923,7 +1923,7 @@ describe('IntersectionObserver', function() {
           expect(rect(records[0].intersectionRect)).to.eql(rect({
             top: 0,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 300
           }));
           expect(records[0].isIntersecting).to.be(true);
@@ -1936,7 +1936,7 @@ describe('IntersectionObserver', function() {
           expect(rect(records[1].intersectionRect)).to.eql(rect({
             top: 0,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 300
           }));
           expect(records[1].isIntersecting).to.be(true);
@@ -1947,13 +1947,13 @@ describe('IntersectionObserver', function() {
           var clientRect1 = rect({
             top: -10,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 200
           });
           var intersectRect1 = rect({
             top: 0,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             // Height is only for the visible area.
             height: 200 - 10
           });
@@ -1984,7 +1984,7 @@ describe('IntersectionObserver', function() {
           expect(rect(records[0].intersectionRect)).to.eql(rect({
             top: 10,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 300 - 10
           }));
           expect(records[0].isIntersecting).to.be(true);
@@ -1997,7 +1997,7 @@ describe('IntersectionObserver', function() {
           expect(rect(records[1].intersectionRect)).to.eql(rect({
             top: 10,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 300 - 10
           }));
           expect(records[1].isIntersecting).to.be(true);
@@ -2084,7 +2084,7 @@ describe('IntersectionObserver', function() {
           var clientRect1 = rect({
             top: 0,
             left: 0,
-            width: 100,
+            width: bodyWidth,
             height: 200
           });
           expect(rect(records[2].boundingClientRect)).to.eql(clientRect1);

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -1619,8 +1619,8 @@ describe('IntersectionObserver', function() {
           var script = iframeDoc.createElement('script');
           script.src = 'intersection-observer.js';
           script.onload = function() {
-            if (iframeWin.IntersectionObserver.polyfillSetupCrossOriginUpdater) {
-              crossOriginUpdater = iframeWin.IntersectionObserver.polyfillSetupCrossOriginUpdater();
+            if (iframeWin.IntersectionObserver._setupCrossOriginUpdater) {
+              crossOriginUpdater = iframeWin.IntersectionObserver._setupCrossOriginUpdater();
             }
             done();
           };
@@ -1631,8 +1631,8 @@ describe('IntersectionObserver', function() {
       });
 
       afterEach(function() {
-        if (IntersectionObserver.polyfillResetCrossOriginUpdater) {
-          IntersectionObserver.polyfillResetCrossOriginUpdater();
+        if (IntersectionObserver._resetCrossOriginUpdater) {
+          IntersectionObserver._resetCrossOriginUpdater();
         }
       });
 

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -941,8 +941,9 @@ describe('IntersectionObserver', function() {
 
   });
 
-  describe('same-origin iframe', function() {
+  describe('iframe', function() {
     var iframe, win, doc;
+    var documentElement, body;
     var iframeTargetEl1, iframeTargetEl2;
     var bodyWidth;
 
@@ -968,6 +969,12 @@ describe('IntersectionObserver', function() {
         iframeDoc.write('.target {height: 200px; margin-bottom: 2px; background: blue;}');
         iframeDoc.write('</style>');
         iframeDoc.close();
+
+        // Ensure the documentElement and body are always sorted on top.
+        documentElement = iframeDoc.documentElement;
+        body = iframeDoc.body;
+        documentElement.id = 'A1';
+        body.id = 'A1';
 
         function createTarget(id, bg) {
           var target = iframeDoc.createElement('div');
@@ -1014,582 +1021,1328 @@ describe('IntersectionObserver', function() {
       });
     }
 
-    it('iframe targets do not intersect with a top root element', function(done) {
-      var io = new IntersectionObserver(function(unsortedRecords) {
-        var records = sortRecords(unsortedRecords);
-        expect(records.length).to.be(2);
-        expect(records[0].isIntersecting).to.be(false);
-        expect(records[1].isIntersecting).to.be(false);
-        done();
-        io.disconnect();
-      }, {root: rootEl});
-      io.observe(iframeTargetEl1);
-      io.observe(iframeTargetEl2);
-    });
-
-    it('triggers for all targets in top-level root', function(done) {
-      var io = new IntersectionObserver(function(unsortedRecords) {
-        var records = sortRecords(unsortedRecords);
-        expect(records.length).to.be(2);
-        expect(records[0].isIntersecting).to.be(true);
-        expect(records[0].intersectionRatio).to.be(1);
-        expect(records[1].isIntersecting).to.be(false);
-        expect(records[1].intersectionRatio).to.be(0);
-
-        // The rootBounds is for the document's root.
-        expect(records[0].rootBounds.height).to.be(innerHeight);
-
-        done();
-        io.disconnect();
-      });
-      io.observe(iframeTargetEl1);
-      io.observe(iframeTargetEl2);
-    });
-
-    it('triggers for all targets in iframe-level root', function(done) {
-      var io = new IntersectionObserver(function(unsortedRecords) {
-        var records = sortRecords(unsortedRecords);
-        expect(records.length).to.be(2);
-        expect(records[0].intersectionRatio).to.be(1);
-        expect(records[1].intersectionRatio).to.be(1);
-
-        // The rootBounds is for the document's root.
-        expect(rect(records[0].rootBounds)).
-          to.eql(rect(iframeDoc.body.getBoundingClientRect()));
-
-        done();
-        io.disconnect();
-      }, {root: iframeDoc.body});
-      io.observe(iframeTargetEl1);
-      io.observe(iframeTargetEl2);
-    });
-
-    it('calculates rects for a fully visible frame', function(done) {
-      iframe.style.top = '0px';
-      iframe.style.height = '300px';
-      var io = new IntersectionObserver(function(unsortedRecords) {
-        var records = sortRecords(unsortedRecords);
-        expect(records.length).to.be(2);
-        expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
-        expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
-
-        // The target1 is fully visible.
-        var clientRect1 = rect({
-          top: 0,
-          left: 0,
-          width: bodyWidth,
-          height: 200
-        });
-        expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
-        expect(rect(records[0].intersectionRect)).to.eql(clientRect1);
-        expect(records[0].isIntersecting).to.be(true);
-        expect(records[0].intersectionRatio).to.be(1);
-
-        // The target2 is partially visible.
-        var clientRect2 = rect({
-          top: 202,
-          left: 0,
-          width: bodyWidth,
-          height: 200
-        });
-        var intersectRect2 = rect({
-          top: 202,
-          left: 0,
-          width: bodyWidth,
-          // The bottom is clipped off.
-          bottom: 300
-        });
-        expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
-        expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
-        expect(records[1].isIntersecting).to.be(true);
-        expect(records[1].intersectionRatio).to.be.within(0.48, 0.5); // ~0.5
-
-        done();
-        io.disconnect();
-      });
-      io.observe(iframeTargetEl1);
-      io.observe(iframeTargetEl2);
-    });
-
-    it('calculates rects for a fully visible and offset frame', function(done) {
-      iframe.style.top = '10px';
-      iframe.style.height = '300px';
-      var io = new IntersectionObserver(function(unsortedRecords) {
-        var records = sortRecords(unsortedRecords);
-        expect(records.length).to.be(2);
-        expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
-        expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
-
-        // The target1 is fully visible.
-        var clientRect1 = rect({
-          top: 0,
-          left: 0,
-          width: bodyWidth,
-          height: 200
-        });
-        expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
-        expect(rect(records[0].intersectionRect)).to.eql(clientRect1);
-        expect(records[0].isIntersecting).to.be(true);
-        expect(records[0].intersectionRatio).to.be(1);
-
-        // The target2 is partially visible.
-        var clientRect2 = rect({
-          top: 202,
-          left: 0,
-          width: bodyWidth,
-          height: 200
-        });
-        var intersectRect2 = rect({
-          top: 202,
-          left: 0,
-          width: bodyWidth,
-          // The bottom is clipped off.
-          bottom: 300
-        });
-        expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
-        expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
-        expect(records[1].isIntersecting).to.be(true);
-        expect(records[1].intersectionRatio).to.be.within(0.48, 0.5); // ~0.5
-
-        done();
-        io.disconnect();
-      });
-      io.observe(iframeTargetEl1);
-      io.observe(iframeTargetEl2);
-    });
-
-    it('calculates rects for a clipped frame on top', function(done) {
-      iframe.style.top = '-10px';
-      iframe.style.height = '300px';
-      var io = new IntersectionObserver(function(unsortedRecords) {
-        var records = sortRecords(unsortedRecords);
-        expect(records.length).to.be(2);
-        expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
-        expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
-
-        // The target1 is clipped at the top by the iframe's clipping.
-        var clientRect1 = rect({
-          top: 0,
-          left: 0,
-          width: bodyWidth,
-          height: 200
-        });
-        var intersectRect1 = rect({
-          left: 0,
-          width: bodyWidth,
-          // Top is clipped.
-          top: 10,
-          height: 200 - 10
-        });
-        expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
-        expect(rect(records[0].intersectionRect)).to.eql(intersectRect1);
-        expect(records[0].isIntersecting).to.be(true);
-        expect(records[0].intersectionRatio).to.within(0.94, 0.96); // ~0.95
-
-        // The target2 is partially visible.
-        var clientRect2 = rect({
-          top: 202,
-          left: 0,
-          width: bodyWidth,
-          height: 200
-        });
-        var intersectRect2 = rect({
-          top: 202,
-          left: 0,
-          width: bodyWidth,
-          // The bottom is clipped off.
-          bottom: 300
-        });
-        expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
-        expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
-        expect(records[1].isIntersecting).to.be(true);
-        expect(records[1].intersectionRatio).to.be.within(0.48, 0.5); // ~0.49
-
-        done();
-        io.disconnect();
-      });
-      io.observe(iframeTargetEl1);
-      io.observe(iframeTargetEl2);
-    });
-
-    it('calculates rects for a clipped frame on bottom', function(done) {
-      iframe.style.top = 'auto';
-      iframe.style.bottom = '-10px';
-      iframe.style.height = '300px';
-      var io = new IntersectionObserver(function(unsortedRecords) {
-        var records = sortRecords(unsortedRecords);
-        expect(records.length).to.be(2);
-        expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
-        expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
-
-        // The target1 is clipped at the top by the iframe's clipping.
-        var clientRect1 = rect({
-          top: 0,
-          left: 0,
-          width: bodyWidth,
-          height: 200
-        });
-        expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
-        expect(rect(records[0].intersectionRect)).to.eql(clientRect1);
-        expect(records[0].isIntersecting).to.be(true);
-        expect(records[0].intersectionRatio).to.be(1);
-
-        // The target2 is partially visible.
-        var clientRect2 = rect({
-          top: 202,
-          left: 0,
-          width: bodyWidth,
-          height: 200
-        });
-        var intersectRect2 = rect({
-          top: 202,
-          left: 0,
-          width: bodyWidth,
-          // The bottom is clipped off.
-          bottom: 300 - 10
-        });
-        expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
-        expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
-        expect(records[1].isIntersecting).to.be(true);
-        expect(records[1].intersectionRatio).to.be.within(0.43, 0.45); // ~0.44
-
-        done();
-        io.disconnect();
-      });
-      io.observe(iframeTargetEl1);
-      io.observe(iframeTargetEl2);
-    });
-
-    it('calculates rects for a fully visible frame and scrolled', function(done) {
-      iframe.style.top = '0px';
-      iframe.style.height = '300px';
-      iframeWin.scrollTo(0, 10);
-      var io = new IntersectionObserver(function(unsortedRecords) {
-        var records = sortRecords(unsortedRecords);
-        expect(records.length).to.be(2);
-        expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
-        expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
-
-        // The target1 is fully visible.
-        var clientRect1 = rect({
-          top: -10,
-          left: 0,
-          width: bodyWidth,
-          height: 200
-        });
-        var intersectRect1 = rect({
-          top: 0,
-          left: 0,
-          width: bodyWidth,
-          // Height is only for the visible area.
-          height: 200 - 10
-        });
-        expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
-        expect(rect(records[0].intersectionRect)).to.eql(intersectRect1);
-        expect(records[0].isIntersecting).to.be(true);
-        expect(records[0].intersectionRatio).to.within(0.94, 0.96); // ~0.95
-
-        // The target2 is partially visible.
-        var clientRect2 = rect({
-          top: 202 - 10,
-          left: 0,
-          width: bodyWidth,
-          height: 200
-        });
-        var intersectRect2 = rect({
-          top: 202 - 10,
-          left: 0,
-          width: bodyWidth,
-          // The bottom is clipped off.
-          bottom: 300
-        });
-        expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
-        expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
-        expect(records[1].isIntersecting).to.be(true);
-        expect(records[1].intersectionRatio).to.be.within(0.53, 0.55); // ~0.54
-
-        done();
-        io.disconnect();
-      });
-      io.observe(iframeTargetEl1);
-      io.observe(iframeTargetEl2);
-    });
-
-    it('calculates rects for a clipped frame on top and scrolled', function(done) {
-      iframe.style.top = '-10px';
-      iframe.style.height = '300px';
-      iframeWin.scrollTo(0, 10);
-      var io = new IntersectionObserver(function(unsortedRecords) {
-        var records = sortRecords(unsortedRecords);
-        expect(records.length).to.be(2);
-        expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
-        expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
-
-        // The target1 is clipped at the top by the iframe's clipping.
-        var clientRect1 = rect({
-          top: -10,
-          left: 0,
-          width: bodyWidth,
-          height: 200
-        });
-        var intersectRect1 = rect({
-          left: 0,
-          width: bodyWidth,
-          // Top is clipped.
-          top: 10,
-          // The height is less by both: offset and scroll.
-          height: 200 - 10 - 10
-        });
-        expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
-        expect(rect(records[0].intersectionRect)).to.eql(intersectRect1);
-        expect(records[0].isIntersecting).to.be(true);
-        expect(records[0].intersectionRatio).to.within(0.89, 0.91); // ~0.9
-
-        // The target2 is partially visible.
-        var clientRect2 = rect({
-          top: 202 - 10,
-          left: 0,
-          width: bodyWidth,
-          height: 200
-        });
-        var intersectRect2 = rect({
-          top: 202 - 10,
-          left: 0,
-          width: bodyWidth,
-          // The bottom is clipped off.
-          bottom: 300
-        });
-        expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
-        expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
-        expect(records[1].isIntersecting).to.be(true);
-        expect(records[1].intersectionRatio).to.be.within(0.53, 0.55); // ~0.54
-
-        done();
-        io.disconnect();
-      });
-      io.observe(iframeTargetEl1);
-      io.observe(iframeTargetEl2);
-    });
-
-    it('handles style changes', function(done) {
-      var spy = sinon.spy();
-
-      // When first element becomes invisible, the second element will show.
-      // And in reverse: when the first element becomes visible again, the
-      // second element will disappear.
-      var io = new IntersectionObserver(spy);
-      io.observe(iframeTargetEl1);
-      io.observe(iframeTargetEl2);
-
-      runSequence([
-        function(done) {
-          setTimeout(function() {
-            expect(spy.callCount).to.be(1);
-            var records = sortRecords(spy.lastCall.args[0]);
-            expect(records.length).to.be(2);
-            expect(records[0].intersectionRatio).to.be(1);
-            expect(records[0].isIntersecting).to.be(true);
-            expect(records[1].intersectionRatio).to.be(0);
-            expect(records[1].isIntersecting).to.be(false);
-            done();
-          }, ASYNC_TIMEOUT);
-        },
-        function(done) {
-          iframeTargetEl1.style.display = 'none';
-          setTimeout(function() {
-            expect(spy.callCount).to.be(2);
-            var records = sortRecords(spy.lastCall.args[0]);
-            expect(records.length).to.be(2);
-            expect(records[0].intersectionRatio).to.be(0);
-            expect(records[0].isIntersecting).to.be(false);
-            expect(records[1].intersectionRatio).to.be(1);
-            expect(records[1].isIntersecting).to.be(true);
-            done();
-          }, ASYNC_TIMEOUT);
-        },
-        function(done) {
-          iframeTargetEl1.style.display = '';
-          setTimeout(function() {
-            expect(spy.callCount).to.be(3);
-            var records = sortRecords(spy.lastCall.args[0]);
-            expect(records.length).to.be(2);
-            expect(records[0].intersectionRatio).to.be(1);
-            expect(records[0].isIntersecting).to.be(true);
-            expect(records[1].intersectionRatio).to.be(0);
-            expect(records[1].isIntersecting).to.be(false);
-            done();
-          }, ASYNC_TIMEOUT);
-        },
-        function(done) {
+    describe('same-origin iframe', function() {
+      it('iframe targets do not intersect with a top root element', function(done) {
+        var io = new IntersectionObserver(function(unsortedRecords) {
+          var records = sortRecords(unsortedRecords);
+          expect(records.length).to.be(2);
+          expect(records[0].isIntersecting).to.be(false);
+          expect(records[1].isIntersecting).to.be(false);
+          done();
           io.disconnect();
+        }, {root: rootEl});
+        io.observe(iframeTargetEl1);
+        io.observe(iframeTargetEl2);
+      });
+
+      it('triggers for all targets in top-level root', function(done) {
+        var io = new IntersectionObserver(function(unsortedRecords) {
+          var records = sortRecords(unsortedRecords);
+          expect(records.length).to.be(2);
+          expect(records[0].isIntersecting).to.be(true);
+          expect(records[0].intersectionRatio).to.be(1);
+          expect(records[1].isIntersecting).to.be(false);
+          expect(records[1].intersectionRatio).to.be(0);
+
+          // The rootBounds is for the document's root.
+          expect(records[0].rootBounds.height).to.be(innerHeight);
+
+          done();
+          io.disconnect();
+        });
+        io.observe(iframeTargetEl1);
+        io.observe(iframeTargetEl2);
+      });
+
+      it('triggers for all targets in iframe-level root', function(done) {
+        var io = new IntersectionObserver(function(unsortedRecords) {
+          var records = sortRecords(unsortedRecords);
+          expect(records.length).to.be(2);
+          expect(records[0].intersectionRatio).to.be(1);
+          expect(records[1].intersectionRatio).to.be(1);
+
+          // The rootBounds is for the document's root.
+          expect(rect(records[0].rootBounds)).
+            to.eql(rect(iframeDoc.body.getBoundingClientRect()));
+
+          done();
+          io.disconnect();
+        }, {root: iframeDoc.body});
+        io.observe(iframeTargetEl1);
+        io.observe(iframeTargetEl2);
+      });
+
+      it('calculates rects for a fully visible frame', function(done) {
+        iframe.style.top = '0px';
+        iframe.style.height = '300px';
+        var io = new IntersectionObserver(function(unsortedRecords) {
+          var records = sortRecords(unsortedRecords);
+          expect(records.length).to.be(2);
+          expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
+          expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
+
+          // The target1 is fully visible.
+          var clientRect1 = rect({
+            top: 0,
+            left: 0,
+            width: bodyWidth,
+            height: 200
+          });
+          expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
+          expect(rect(records[0].intersectionRect)).to.eql(clientRect1);
+          expect(records[0].isIntersecting).to.be(true);
+          expect(records[0].intersectionRatio).to.be(1);
+
+          // The target2 is partially visible.
+          var clientRect2 = rect({
+            top: 202,
+            left: 0,
+            width: bodyWidth,
+            height: 200
+          });
+          var intersectRect2 = rect({
+            top: 202,
+            left: 0,
+            width: bodyWidth,
+            // The bottom is clipped off.
+            bottom: 300
+          });
+          expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
+          expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
+          expect(records[1].isIntersecting).to.be(true);
+          expect(records[1].intersectionRatio).to.be.within(0.48, 0.5); // ~0.5
+
+          done();
+          io.disconnect();
+        });
+        io.observe(iframeTargetEl1);
+        io.observe(iframeTargetEl2);
+      });
+
+      it('calculates rects for a fully visible and offset frame', function(done) {
+        iframe.style.top = '10px';
+        iframe.style.height = '300px';
+        var io = new IntersectionObserver(function(unsortedRecords) {
+          var records = sortRecords(unsortedRecords);
+          expect(records.length).to.be(2);
+          expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
+          expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
+
+          // The target1 is fully visible.
+          var clientRect1 = rect({
+            top: 0,
+            left: 0,
+            width: bodyWidth,
+            height: 200
+          });
+          expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
+          expect(rect(records[0].intersectionRect)).to.eql(clientRect1);
+          expect(records[0].isIntersecting).to.be(true);
+          expect(records[0].intersectionRatio).to.be(1);
+
+          // The target2 is partially visible.
+          var clientRect2 = rect({
+            top: 202,
+            left: 0,
+            width: bodyWidth,
+            height: 200
+          });
+          var intersectRect2 = rect({
+            top: 202,
+            left: 0,
+            width: bodyWidth,
+            // The bottom is clipped off.
+            bottom: 300
+          });
+          expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
+          expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
+          expect(records[1].isIntersecting).to.be(true);
+          expect(records[1].intersectionRatio).to.be.within(0.48, 0.5); // ~0.5
+
+          done();
+          io.disconnect();
+        });
+        io.observe(iframeTargetEl1);
+        io.observe(iframeTargetEl2);
+      });
+
+      it('calculates rects for a clipped frame on top', function(done) {
+        iframe.style.top = '-10px';
+        iframe.style.height = '300px';
+        var io = new IntersectionObserver(function(unsortedRecords) {
+          var records = sortRecords(unsortedRecords);
+          expect(records.length).to.be(2);
+          expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
+          expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
+
+          // The target1 is clipped at the top by the iframe's clipping.
+          var clientRect1 = rect({
+            top: 0,
+            left: 0,
+            width: bodyWidth,
+            height: 200
+          });
+          var intersectRect1 = rect({
+            left: 0,
+            width: bodyWidth,
+            // Top is clipped.
+            top: 10,
+            height: 200 - 10
+          });
+          expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
+          expect(rect(records[0].intersectionRect)).to.eql(intersectRect1);
+          expect(records[0].isIntersecting).to.be(true);
+          expect(records[0].intersectionRatio).to.within(0.94, 0.96); // ~0.95
+
+          // The target2 is partially visible.
+          var clientRect2 = rect({
+            top: 202,
+            left: 0,
+            width: bodyWidth,
+            height: 200
+          });
+          var intersectRect2 = rect({
+            top: 202,
+            left: 0,
+            width: bodyWidth,
+            // The bottom is clipped off.
+            bottom: 300
+          });
+          expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
+          expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
+          expect(records[1].isIntersecting).to.be(true);
+          expect(records[1].intersectionRatio).to.be.within(0.48, 0.5); // ~0.49
+
+          done();
+          io.disconnect();
+        });
+        io.observe(iframeTargetEl1);
+        io.observe(iframeTargetEl2);
+      });
+
+      it('calculates rects for a clipped frame on bottom', function(done) {
+        iframe.style.top = 'auto';
+        iframe.style.bottom = '-10px';
+        iframe.style.height = '300px';
+        var io = new IntersectionObserver(function(unsortedRecords) {
+          var records = sortRecords(unsortedRecords);
+          expect(records.length).to.be(2);
+          expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
+          expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
+
+          // The target1 is clipped at the top by the iframe's clipping.
+          var clientRect1 = rect({
+            top: 0,
+            left: 0,
+            width: bodyWidth,
+            height: 200
+          });
+          expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
+          expect(rect(records[0].intersectionRect)).to.eql(clientRect1);
+          expect(records[0].isIntersecting).to.be(true);
+          expect(records[0].intersectionRatio).to.be(1);
+
+          // The target2 is partially visible.
+          var clientRect2 = rect({
+            top: 202,
+            left: 0,
+            width: bodyWidth,
+            height: 200
+          });
+          var intersectRect2 = rect({
+            top: 202,
+            left: 0,
+            width: bodyWidth,
+            // The bottom is clipped off.
+            bottom: 300 - 10
+          });
+          expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
+          expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
+          expect(records[1].isIntersecting).to.be(true);
+          expect(records[1].intersectionRatio).to.be.within(0.43, 0.45); // ~0.44
+
+          done();
+          io.disconnect();
+        });
+        io.observe(iframeTargetEl1);
+        io.observe(iframeTargetEl2);
+      });
+
+      it('calculates rects for a fully visible frame and scrolled', function(done) {
+        iframe.style.top = '0px';
+        iframe.style.height = '300px';
+        iframeWin.scrollTo(0, 10);
+        var io = new IntersectionObserver(function(unsortedRecords) {
+          var records = sortRecords(unsortedRecords);
+          expect(records.length).to.be(2);
+          expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
+          expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
+
+          // The target1 is fully visible.
+          var clientRect1 = rect({
+            top: -10,
+            left: 0,
+            width: bodyWidth,
+            height: 200
+          });
+          var intersectRect1 = rect({
+            top: 0,
+            left: 0,
+            width: bodyWidth,
+            // Height is only for the visible area.
+            height: 200 - 10
+          });
+          expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
+          expect(rect(records[0].intersectionRect)).to.eql(intersectRect1);
+          expect(records[0].isIntersecting).to.be(true);
+          expect(records[0].intersectionRatio).to.within(0.94, 0.96); // ~0.95
+
+          // The target2 is partially visible.
+          var clientRect2 = rect({
+            top: 202 - 10,
+            left: 0,
+            width: bodyWidth,
+            height: 200
+          });
+          var intersectRect2 = rect({
+            top: 202 - 10,
+            left: 0,
+            width: bodyWidth,
+            // The bottom is clipped off.
+            bottom: 300
+          });
+          expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
+          expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
+          expect(records[1].isIntersecting).to.be(true);
+          expect(records[1].intersectionRatio).to.be.within(0.53, 0.55); // ~0.54
+
+          done();
+          io.disconnect();
+        });
+        io.observe(iframeTargetEl1);
+        io.observe(iframeTargetEl2);
+      });
+
+      it('calculates rects for a clipped frame on top and scrolled', function(done) {
+        iframe.style.top = '-10px';
+        iframe.style.height = '300px';
+        iframeWin.scrollTo(0, 10);
+        var io = new IntersectionObserver(function(unsortedRecords) {
+          var records = sortRecords(unsortedRecords);
+          expect(records.length).to.be(2);
+          expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
+          expect(rect(records[1].rootBounds)).to.eql(getRootRect(document));
+
+          // The target1 is clipped at the top by the iframe's clipping.
+          var clientRect1 = rect({
+            top: -10,
+            left: 0,
+            width: bodyWidth,
+            height: 200
+          });
+          var intersectRect1 = rect({
+            left: 0,
+            width: bodyWidth,
+            // Top is clipped.
+            top: 10,
+            // The height is less by both: offset and scroll.
+            height: 200 - 10 - 10
+          });
+          expect(rect(records[0].boundingClientRect)).to.eql(clientRect1);
+          expect(rect(records[0].intersectionRect)).to.eql(intersectRect1);
+          expect(records[0].isIntersecting).to.be(true);
+          expect(records[0].intersectionRatio).to.within(0.89, 0.91); // ~0.9
+
+          // The target2 is partially visible.
+          var clientRect2 = rect({
+            top: 202 - 10,
+            left: 0,
+            width: bodyWidth,
+            height: 200
+          });
+          var intersectRect2 = rect({
+            top: 202 - 10,
+            left: 0,
+            width: bodyWidth,
+            // The bottom is clipped off.
+            bottom: 300
+          });
+          expect(rect(records[1].boundingClientRect)).to.eql(clientRect2);
+          expect(rect(records[1].intersectionRect)).to.eql(intersectRect2);
+          expect(records[1].isIntersecting).to.be(true);
+          expect(records[1].intersectionRatio).to.be.within(0.53, 0.55); // ~0.54
+
+          done();
+          io.disconnect();
+        });
+        io.observe(iframeTargetEl1);
+        io.observe(iframeTargetEl2);
+      });
+
+      it('handles style changes', function(done) {
+        var spy = sinon.spy();
+
+        // When first element becomes invisible, the second element will show.
+        // And in reverse: when the first element becomes visible again, the
+        // second element will disappear.
+        var io = new IntersectionObserver(spy);
+        io.observe(iframeTargetEl1);
+        io.observe(iframeTargetEl2);
+
+        runSequence([
+          function(done) {
+            setTimeout(function() {
+              expect(spy.callCount).to.be(1);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(2);
+              expect(records[0].intersectionRatio).to.be(1);
+              expect(records[0].isIntersecting).to.be(true);
+              expect(records[1].intersectionRatio).to.be(0);
+              expect(records[1].isIntersecting).to.be(false);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            iframeTargetEl1.style.display = 'none';
+            setTimeout(function() {
+              expect(spy.callCount).to.be(2);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(2);
+              expect(records[0].intersectionRatio).to.be(0);
+              expect(records[0].isIntersecting).to.be(false);
+              expect(records[1].intersectionRatio).to.be(1);
+              expect(records[1].isIntersecting).to.be(true);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            iframeTargetEl1.style.display = '';
+            setTimeout(function() {
+              expect(spy.callCount).to.be(3);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(2);
+              expect(records[0].intersectionRatio).to.be(1);
+              expect(records[0].isIntersecting).to.be(true);
+              expect(records[1].intersectionRatio).to.be(0);
+              expect(records[1].isIntersecting).to.be(false);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            io.disconnect();
+            done();
+          }
+        ], done);
+      });
+
+      it('handles scroll changes', function(done) {
+        var spy = sinon.spy();
+
+        // Scrolling to the middle of the iframe shows the second box and
+        // hides the first.
+        var io = new IntersectionObserver(spy);
+        io.observe(iframeTargetEl1);
+        io.observe(iframeTargetEl2);
+
+        runSequence([
+          function(done) {
+            setTimeout(function() {
+              expect(spy.callCount).to.be(1);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(2);
+              expect(records[0].intersectionRatio).to.be(1);
+              expect(records[0].isIntersecting).to.be(true);
+              expect(records[1].intersectionRatio).to.be(0);
+              expect(records[1].isIntersecting).to.be(false);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            iframeWin.scrollTo(0, 202);
+            setTimeout(function() {
+              expect(spy.callCount).to.be(2);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(2);
+              expect(records[0].intersectionRatio).to.be(0);
+              expect(records[0].isIntersecting).to.be(false);
+              expect(records[1].intersectionRatio).to.be(1);
+              expect(records[1].isIntersecting).to.be(true);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            iframeWin.scrollTo(0, 0);
+            setTimeout(function() {
+              expect(spy.callCount).to.be(3);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(2);
+              expect(records[0].intersectionRatio).to.be(1);
+              expect(records[0].isIntersecting).to.be(true);
+              expect(records[1].intersectionRatio).to.be(0);
+              expect(records[1].isIntersecting).to.be(false);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            io.disconnect();
+            done();
+          }
+        ], done);
+      });
+
+      it('handles iframe changes', function(done) {
+        var spy = sinon.spy();
+
+        // Iframe goes off screen and returns.
+        var io = new IntersectionObserver(spy);
+        io.observe(iframeTargetEl1);
+        io.observe(iframeTargetEl2);
+
+        runSequence([
+          function(done) {
+            setTimeout(function() {
+              expect(spy.callCount).to.be(1);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(2);
+              expect(records[0].intersectionRatio).to.be(1);
+              expect(records[0].isIntersecting).to.be(true);
+              expect(records[1].intersectionRatio).to.be(0);
+              expect(records[1].isIntersecting).to.be(false);
+              // Top-level bounds.
+              expect(records[0].rootBounds.height).to.be(innerHeight);
+              expect(records[0].intersectionRect.height).to.be(200);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            // Completely off screen.
+            iframe.style.top = '-202px';
+            setTimeout(function() {
+              expect(spy.callCount).to.be(2);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(1);
+              expect(records[0].intersectionRatio).to.be(0);
+              expect(records[0].isIntersecting).to.be(false);
+              // Top-level bounds.
+              expect(records[0].rootBounds.height).to.be(innerHeight);
+              expect(records[0].intersectionRect.height).to.be(0);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            // Partially returns.
+            iframe.style.top = '-100px';
+            setTimeout(function() {
+              expect(spy.callCount).to.be(3);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(1);
+              expect(records[0].intersectionRatio).to.be.within(0.45, 0.55);
+              expect(records[0].isIntersecting).to.be(true);
+              // Top-level bounds.
+              expect(records[0].rootBounds.height).to.be(innerHeight);
+              expect(records[0].intersectionRect.height / 200).to.be.within(0.45, 0.55);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            io.disconnect();
+            done();
+          }
+        ], done);
+      });
+
+      it('continues to monitor until the last target unobserved', function(done) {
+        var spy = sinon.spy();
+
+        // Iframe goes off screen and returns.
+        var io = new IntersectionObserver(spy);
+        io.observe(target1);
+        io.observe(iframeTargetEl1);
+        io.observe(iframeTargetEl2);
+
+        runSequence([
+          function(done) {
+            setTimeout(function() {
+              expect(spy.callCount).to.be(1);
+              expect(spy.lastCall.args[0].length).to.be(3);
+
+              // Unobserve one from the main context and one from iframe.
+              io.unobserve(target1);
+              io.unobserve(iframeTargetEl2);
+
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            // Completely off screen.
+            iframe.style.top = '-202px';
+            setTimeout(function() {
+              expect(spy.callCount).to.be(2);
+              expect(spy.lastCall.args[0].length).to.be(1);
+
+              io.unobserve(iframeTargetEl1);
+
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            // Partially returns.
+            iframe.style.top = '-100px';
+            setTimeout(function() {
+              expect(spy.callCount).to.be(2);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            io.disconnect();
+            done();
+          }
+        ], done);
+      });
+    });
+
+    describe('cross-origin iframe', function() {
+      var ASYNC_TIMEOUT = 300;
+      var crossOriginUpdater;
+
+      beforeEach(function(done) {
+        Object.defineProperty(iframeWin, 'frameElement', {value: null});
+
+        /* Uncomment these lines to force polyfill inside the iframe.
+        delete iframeWin.IntersectionObserver;
+        delete iframeWin.IntersectionObserverEntry;
+        */
+
+        // Install polyfill right into the iframe.
+        if (!iframeWin.IntersectionObserver) {
+          var script = iframeDoc.createElement('script');
+          script.src = 'intersection-observer.js';
+          script.onload = function() {
+            if (iframeWin.IntersectionObserver.polyfillSetupCrossOriginUpdater) {
+              crossOriginUpdater = iframeWin.IntersectionObserver.polyfillSetupCrossOriginUpdater();
+            }
+            done();
+          };
+          iframeDoc.body.appendChild(script);
+        } else {
           done();
         }
-      ], done);
-    });
+      });
 
-    it('handles scroll changes', function(done) {
-      var spy = sinon.spy();
-
-      // Scrolling to the middle of the iframe shows the second box and
-      // hides the first.
-      var io = new IntersectionObserver(spy);
-      io.observe(iframeTargetEl1);
-      io.observe(iframeTargetEl2);
-
-      runSequence([
-        function(done) {
-          setTimeout(function() {
-            expect(spy.callCount).to.be(1);
-            var records = sortRecords(spy.lastCall.args[0]);
-            expect(records.length).to.be(2);
-            expect(records[0].intersectionRatio).to.be(1);
-            expect(records[0].isIntersecting).to.be(true);
-            expect(records[1].intersectionRatio).to.be(0);
-            expect(records[1].isIntersecting).to.be(false);
-            done();
-          }, ASYNC_TIMEOUT);
-        },
-        function(done) {
-          iframeWin.scrollTo(0, 202);
-          setTimeout(function() {
-            expect(spy.callCount).to.be(2);
-            var records = sortRecords(spy.lastCall.args[0]);
-            expect(records.length).to.be(2);
-            expect(records[0].intersectionRatio).to.be(0);
-            expect(records[0].isIntersecting).to.be(false);
-            expect(records[1].intersectionRatio).to.be(1);
-            expect(records[1].isIntersecting).to.be(true);
-            done();
-          }, ASYNC_TIMEOUT);
-        },
-        function(done) {
-          iframeWin.scrollTo(0, 0);
-          setTimeout(function() {
-            expect(spy.callCount).to.be(3);
-            var records = sortRecords(spy.lastCall.args[0]);
-            expect(records.length).to.be(2);
-            expect(records[0].intersectionRatio).to.be(1);
-            expect(records[0].isIntersecting).to.be(true);
-            expect(records[1].intersectionRatio).to.be(0);
-            expect(records[1].isIntersecting).to.be(false);
-            done();
-          }, ASYNC_TIMEOUT);
-        },
-        function(done) {
-          io.disconnect();
-          done();
+      afterEach(function() {
+        if (IntersectionObserver.polyfillResetCrossOriginUpdater) {
+          IntersectionObserver.polyfillResetCrossOriginUpdater();
         }
-      ], done);
-    });
+      });
 
-    it('handles iframe changes', function(done) {
-      var spy = sinon.spy();
+      function computeRectIntersection(rect1, rect2) {
+        var top = Math.max(rect1.top, rect2.top);
+        var bottom = Math.min(rect1.bottom, rect2.bottom);
+        var left = Math.max(rect1.left, rect2.left);
+        var right = Math.min(rect1.right, rect2.right);
+        var width = right - left;
+        var height = bottom - top;
 
-      // Iframe goes off screen and returns.
-      var io = new IntersectionObserver(spy);
-      io.observe(iframeTargetEl1);
-      io.observe(iframeTargetEl2);
+        return (width >= 0 && height >= 0) && {
+          top: top,
+          bottom: bottom,
+          left: left,
+          right: right,
+          width: width,
+          height: height
+        } || {
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0,
+          width: 0,
+          height: 0
+        };
+      }
 
-      runSequence([
-        function(done) {
-          setTimeout(function() {
-            expect(spy.callCount).to.be(1);
-            var records = sortRecords(spy.lastCall.args[0]);
-            expect(records.length).to.be(2);
-            expect(records[0].intersectionRatio).to.be(1);
-            expect(records[0].isIntersecting).to.be(true);
-            expect(records[1].intersectionRatio).to.be(0);
-            expect(records[1].isIntersecting).to.be(false);
-            // Top-level bounds.
-            expect(records[0].rootBounds.height).to.be(innerHeight);
-            expect(records[0].intersectionRect.height).to.be(200);
-            done();
-          }, ASYNC_TIMEOUT);
-        },
-        function(done) {
-          // Completely off screen.
-          iframe.style.top = '-202px';
-          setTimeout(function() {
-            expect(spy.callCount).to.be(2);
-            var records = sortRecords(spy.lastCall.args[0]);
-            expect(records.length).to.be(1);
-            expect(records[0].intersectionRatio).to.be(0);
-            expect(records[0].isIntersecting).to.be(false);
-            // Top-level bounds.
-            expect(records[0].rootBounds.height).to.be(innerHeight);
-            expect(records[0].intersectionRect.height).to.be(0);
-            done();
-          }, ASYNC_TIMEOUT);
-        },
-        function(done) {
-          // Partially returns.
-          iframe.style.top = '-100px';
-          setTimeout(function() {
-            expect(spy.callCount).to.be(3);
-            var records = sortRecords(spy.lastCall.args[0]);
-            expect(records.length).to.be(1);
-            expect(records[0].intersectionRatio).to.be.within(0.45, 0.55);
-            expect(records[0].isIntersecting).to.be(true);
-            // Top-level bounds.
-            expect(records[0].rootBounds.height).to.be(innerHeight);
-            expect(records[0].intersectionRect.height / 200).to.be.within(0.45, 0.55);
-            done();
-          }, ASYNC_TIMEOUT);
-        },
-        function(done) {
-          io.disconnect();
-          done();
+      function checkRootBoundsAreNull(records) {
+        if (!supportsNativeIntersectionObserver(iframeWin)) {
+          records.forEach(function(record) {
+            expect(record.rootBounds).to.be(null);
+          });
         }
-      ], done);
-    });
+      }
 
-    it('continues to monitor until the last target unobserved', function(done) {
-      var spy = sinon.spy();
-
-      // Iframe goes off screen and returns.
-      var io = new IntersectionObserver(spy);
-      io.observe(target1);
-      io.observe(iframeTargetEl1);
-      io.observe(iframeTargetEl2);
-
-      runSequence([
-        function(done) {
-          setTimeout(function() {
-            expect(spy.callCount).to.be(1);
-            expect(spy.lastCall.args[0].length).to.be(3);
-
-            // Unobserve one from the main context and one from iframe.
-            io.unobserve(target1);
-            io.unobserve(iframeTargetEl2);
-
-            done();
-          }, ASYNC_TIMEOUT);
-        },
-        function(done) {
-          // Completely off screen.
-          iframe.style.top = '-202px';
-          setTimeout(function() {
-            expect(spy.callCount).to.be(2);
-            expect(spy.lastCall.args[0].length).to.be(1);
-
-            io.unobserve(iframeTargetEl1);
-
-            done();
-          }, ASYNC_TIMEOUT);
-        },
-        function(done) {
-          // Partially returns.
-          iframe.style.top = '-100px';
-          setTimeout(function() {
-            expect(spy.callCount).to.be(2);
-            done();
-          }, ASYNC_TIMEOUT);
-        },
-        function(done) {
-          io.disconnect();
-          done();
+      function applyParentRect(parentRect) {
+        if (crossOriginUpdater) {
+          var parentIntersectionRect = computeRectIntersection(
+              parentRect, getRootRect(document));
+          crossOriginUpdater(parentRect, parentIntersectionRect);
+        } else {
+          iframe.style.top = parentRect.top + 'px';
+          iframe.style.left = parentRect.left + 'px';
+          iframe.style.height = parentRect.height + 'px';
+          iframe.style.width = parentRect.width + 'px';
         }
-      ], done);
+      }
+
+      function createObserver(callback, options, parentRect) {
+        var io = new iframeWin.IntersectionObserver(callback, options);
+        if (parentRect) {
+          applyParentRect(parentRect);
+        }
+        return io;
+      }
+
+      it('calculates rects for a fully visible frame', function(done) {
+        var parentRect = rect({top: 0, left: 20, height: 300, width: 100});
+        var io = createObserver(function(unsortedRecords) {
+          var records = sortRecords(unsortedRecords);
+          expect(records.length).to.be(3);
+          checkRootBoundsAreNull(records);
+
+          // The documentElement is partially visible.
+          expect(rect(records[0].boundingClientRect))
+              .to.eql(rect(documentElement.getBoundingClientRect()));
+          expect(rect(records[0].intersectionRect)).to.eql(rect({
+            top: 0,
+            left: 0,
+            width: 100,
+            height: 300
+          }));
+          expect(records[0].isIntersecting).to.be(true);
+          // 300 / 404 == ~0.743
+          expect(records[0].intersectionRatio).to.be.within(0.74, 0.75);
+
+          // The document.body is partially visible.
+          expect(rect(records[1].boundingClientRect))
+              .to.eql(rect(body.getBoundingClientRect()));
+          expect(rect(records[1].intersectionRect)).to.eql(rect({
+            top: 0,
+            left: 0,
+            width: 100,
+            height: 300
+          }));
+          expect(records[1].isIntersecting).to.be(true);
+          // 300 / 402 == ~0.746
+          expect(records[1].intersectionRatio).to.be.within(0.74, 0.75);
+
+          // The target1 is fully visible.
+          var clientRect1 = rect({
+            top: 0,
+            left: 0,
+            width: 100,
+            height: 200
+          });
+          expect(rect(records[2].boundingClientRect)).to.eql(clientRect1);
+          expect(rect(records[2].intersectionRect)).to.eql(clientRect1);
+          expect(records[2].isIntersecting).to.be(true);
+          expect(records[2].intersectionRatio).to.be(1);
+
+          done();
+          io.disconnect();
+        }, {}, parentRect);
+        io.observe(documentElement);
+        io.observe(body);
+        io.observe(iframeTargetEl1);
+      });
+
+      it('calculates rects for a fully visible and offset frame', function(done) {
+        var parentRect = rect({top: 10, left: 20, height: 300, width: 100});
+        var io = createObserver(function(unsortedRecords) {
+          var records = sortRecords(unsortedRecords);
+          expect(records.length).to.be(3);
+          checkRootBoundsAreNull(records);
+
+          // The documentElement is partially visible.
+          expect(rect(records[0].boundingClientRect))
+              .to.eql(rect(documentElement.getBoundingClientRect()));
+          expect(rect(records[0].intersectionRect)).to.eql(rect({
+            top: 0,
+            left: 0,
+            width: 100,
+            height: 300
+          }));
+          expect(records[0].isIntersecting).to.be(true);
+          // 300 / 404 == ~0.743
+          expect(records[0].intersectionRatio).to.be.within(0.74, 0.75);
+
+          // The document.body is partially visible.
+          expect(rect(records[1].boundingClientRect))
+              .to.eql(rect(body.getBoundingClientRect()));
+          expect(rect(records[1].intersectionRect)).to.eql(rect({
+            top: 0,
+            left: 0,
+            width: 100,
+            height: 300
+          }));
+          expect(records[1].isIntersecting).to.be(true);
+          // 300 / 402 == ~0.746
+          expect(records[1].intersectionRatio).to.be.within(0.74, 0.75);
+
+          // The target1 is fully visible.
+          var clientRect1 = rect({
+            top: 0,
+            left: 0,
+            width: 100,
+            height: 200
+          });
+          expect(rect(records[2].boundingClientRect)).to.eql(clientRect1);
+          expect(rect(records[2].intersectionRect)).to.eql(clientRect1);
+          expect(records[2].isIntersecting).to.be(true);
+          expect(records[2].intersectionRatio).to.be(1);
+
+          done();
+          io.disconnect();
+        }, {}, parentRect);
+        io.observe(documentElement);
+        io.observe(body);
+        io.observe(iframeTargetEl1);
+      });
+
+      it('calculates rects for a clipped frame on top', function(done) {
+        var parentRect = rect({top: -10, left: 20, height: 300, width: 100});
+        var io = createObserver(function(unsortedRecords) {
+          var records = sortRecords(unsortedRecords);
+          expect(records.length).to.be(3);
+          checkRootBoundsAreNull(records);
+
+          // The documentElement is partially visible.
+          expect(rect(records[0].boundingClientRect))
+              .to.eql(rect(documentElement.getBoundingClientRect()));
+          expect(rect(records[0].intersectionRect)).to.eql(rect({
+            top: 10,
+            left: 0,
+            width: 100,
+            height: 300 - 10
+          }));
+          expect(records[0].isIntersecting).to.be(true);
+          // (300 - 10) / 404 == ~0.717
+          expect(records[0].intersectionRatio).to.be.within(0.71, 0.72);
+
+          // The document.body is partially visible.
+          expect(rect(records[1].boundingClientRect))
+              .to.eql(rect(body.getBoundingClientRect()));
+          expect(rect(records[1].intersectionRect)).to.eql(rect({
+            top: 10,
+            left: 0,
+            width: 100,
+            height: 300 - 10
+          }));
+          expect(records[1].isIntersecting).to.be(true);
+          // (300 - 10) / 402 == ~0.721
+          expect(records[1].intersectionRatio).to.be.within(0.72, 0.73);
+
+          // The target1 is clipped at the top by the iframe's clipping.
+          var clientRect1 = rect({
+            top: 0,
+            left: 0,
+            width: 100,
+            height: 200
+          });
+          var intersectRect1 = rect({
+            left: 0,
+            width: 100,
+            // Top is clipped.
+            top: 10,
+            height: 200 - 10
+          });
+          expect(rect(records[2].boundingClientRect)).to.eql(clientRect1);
+          expect(rect(records[2].intersectionRect)).to.eql(intersectRect1);
+          expect(records[2].isIntersecting).to.be(true);
+          expect(records[2].intersectionRatio).to.within(0.94, 0.96); // ~0.95
+
+          done();
+          io.disconnect();
+        }, {}, parentRect);
+        io.observe(documentElement);
+        io.observe(body);
+        io.observe(iframeTargetEl1);
+      });
+
+      it('calculates rects for a clipped frame on bottom', function(done) {
+        var rootRect = getRootRect(document);
+        var parentRect = rect({top: rootRect.bottom - 300 + 10, left: 20, height: 300, width: 100});
+        var io = createObserver(function(unsortedRecords) {
+          var records = sortRecords(unsortedRecords);
+          expect(records.length).to.be(3);
+          checkRootBoundsAreNull(records);
+
+          // The documentElement is partially visible.
+          expect(rect(records[0].boundingClientRect))
+              .to.eql(rect(documentElement.getBoundingClientRect()));
+          expect(rect(records[0].intersectionRect)).to.eql(rect({
+            top: 0,
+            left: 0,
+            width: 100,
+            height: 300 - 10
+          }));
+          expect(records[0].isIntersecting).to.be(true);
+          // (300 - 10) / 404 == ~0.717
+          expect(records[0].intersectionRatio).to.be.within(0.71, 0.72);
+
+          // The document.body is partially visible.
+          expect(rect(records[1].boundingClientRect))
+              .to.eql(rect(body.getBoundingClientRect()));
+          expect(rect(records[1].intersectionRect)).to.eql(rect({
+            top: 0,
+            left: 0,
+            width: 100,
+            height: 300 - 10
+          }));
+          expect(records[1].isIntersecting).to.be(true);
+          // (300 - 10) / 402 == ~0.721
+          expect(records[1].intersectionRatio).to.be.within(0.72, 0.73);
+
+          // The target1 is clipped at the top by the iframe's clipping.
+          var clientRect1 = rect({
+            top: 0,
+            left: 0,
+            width: 100,
+            height: 200
+          });
+          expect(rect(records[2].boundingClientRect)).to.eql(clientRect1);
+          expect(rect(records[2].intersectionRect)).to.eql(clientRect1);
+          expect(records[2].isIntersecting).to.be(true);
+          expect(records[2].intersectionRatio).to.be(1);
+
+          done();
+          io.disconnect();
+        }, {}, parentRect);
+        io.observe(documentElement);
+        io.observe(body);
+        io.observe(iframeTargetEl1);
+      });
+
+      it('calculates rects for a fully visible frame and scrolled', function(done) {
+        iframeWin.scrollTo(0, 10);
+        var parentRect = rect({top: 0, left: 20, height: 300, width: 100});
+        var io = createObserver(function(unsortedRecords) {
+          var records = sortRecords(unsortedRecords);
+          expect(records.length).to.be(3);
+          checkRootBoundsAreNull(records);
+
+          // The documentElement is partially visible.
+          expect(rect(records[0].boundingClientRect))
+              .to.eql(rect(documentElement.getBoundingClientRect()));
+          expect(rect(records[0].intersectionRect)).to.eql(rect({
+            top: 0,
+            left: 0,
+            width: 100,
+            height: 300
+          }));
+          expect(records[0].isIntersecting).to.be(true);
+          // 300 / 404 == ~0.743
+          expect(records[0].intersectionRatio).to.be.within(0.74, 0.75);
+
+          // The document.body is partially visible.
+          expect(rect(records[1].boundingClientRect))
+              .to.eql(rect(body.getBoundingClientRect()));
+          expect(rect(records[1].intersectionRect)).to.eql(rect({
+            top: 0,
+            left: 0,
+            width: 100,
+            height: 300
+          }));
+          expect(records[1].isIntersecting).to.be(true);
+          // 300 / 402 == ~0.746
+          expect(records[1].intersectionRatio).to.be.within(0.74, 0.75);
+
+          // The target1 is fully visible.
+          var clientRect1 = rect({
+            top: -10,
+            left: 0,
+            width: 100,
+            height: 200
+          });
+          var intersectRect1 = rect({
+            top: 0,
+            left: 0,
+            width: 100,
+            // Height is only for the visible area.
+            height: 200 - 10
+          });
+          expect(rect(records[2].boundingClientRect)).to.eql(clientRect1);
+          expect(rect(records[2].intersectionRect)).to.eql(intersectRect1);
+          expect(records[2].isIntersecting).to.be(true);
+          expect(records[2].intersectionRatio).to.within(0.94, 0.96); // ~0.95
+
+          done();
+          io.disconnect();
+        }, {}, parentRect);
+        io.observe(documentElement);
+        io.observe(body);
+        io.observe(iframeTargetEl1);
+      });
+
+      it('calculates rects for a clipped frame on top and scrolled', function(done) {
+        iframeWin.scrollTo(0, 10);
+        var parentRect = rect({top: -10, left: 0, height: 300, width: 100});
+        var io = createObserver(function(unsortedRecords) {
+          var records = sortRecords(unsortedRecords);
+          expect(records.length).to.be(4);
+          checkRootBoundsAreNull(records);
+
+          // The documentElement is partially visible.
+          expect(rect(records[0].boundingClientRect))
+              .to.eql(rect(documentElement.getBoundingClientRect()));
+          expect(rect(records[0].intersectionRect)).to.eql(rect({
+            top: 10,
+            left: 0,
+            width: 100,
+            height: 300 - 10
+          }));
+          expect(records[0].isIntersecting).to.be(true);
+          // (300 - 10) / 404 == ~0.717
+          expect(records[0].intersectionRatio).to.be.within(0.71, 0.72);
+
+          // The document.body is partially visible.
+          expect(rect(records[1].boundingClientRect))
+              .to.eql(rect(body.getBoundingClientRect()));
+          expect(rect(records[1].intersectionRect)).to.eql(rect({
+            top: 10,
+            left: 0,
+            width: 100,
+            height: 300 - 10
+          }));
+          expect(records[1].isIntersecting).to.be(true);
+          // (300 - 10) / 402 == ~0.721
+          expect(records[1].intersectionRatio).to.be.within(0.72, 0.73);
+
+          // The target1 is clipped at the top by the iframe's clipping.
+          var clientRect1 = rect({
+            top: -10,
+            left: 0,
+            width: bodyWidth,
+            height: 200
+          });
+          var intersectRect1 = rect({
+            left: 0,
+            width: bodyWidth,
+            // Top is clipped.
+            top: 10,
+            // The height is less by both: offset and scroll.
+            height: 200 - 10 - 10
+          });
+          expect(rect(records[2].boundingClientRect)).to.eql(clientRect1);
+          expect(rect(records[2].intersectionRect)).to.eql(intersectRect1);
+          expect(records[2].isIntersecting).to.be(true);
+          expect(records[2].intersectionRatio).to.within(0.89, 0.91); // ~0.9
+
+          // The target2 is partially visible.
+          var clientRect2 = rect({
+            top: 202 - 10,
+            left: 0,
+            width: bodyWidth,
+            height: 200
+          });
+          var intersectRect2 = rect({
+            top: 202 - 10,
+            left: 0,
+            width: bodyWidth,
+            // The bottom is clipped off.
+            bottom: 300
+          });
+          expect(rect(records[3].boundingClientRect)).to.eql(clientRect2);
+          expect(rect(records[3].intersectionRect)).to.eql(intersectRect2);
+          expect(records[3].isIntersecting).to.be(true);
+          expect(records[3].intersectionRatio).to.be.within(0.53, 0.55); // ~0.54
+
+          done();
+          io.disconnect();
+        }, {}, parentRect);
+        io.observe(documentElement);
+        io.observe(body);
+        io.observe(iframeTargetEl1);
+        io.observe(iframeTargetEl2);
+      });
+
+      it('calculates rects for a fully clipped frame', function(done) {
+        var parentRect = rect({top: -400, left: 20, height: 300, width: 100});
+        var io = createObserver(function(unsortedRecords) {
+          var records = sortRecords(unsortedRecords);
+          expect(records.length).to.be(3);
+          checkRootBoundsAreNull(records);
+
+          var emptyRect = rect({
+            top: 0,
+            left: 0,
+            width: 0,
+            height: 0
+          });
+
+          // The documentElement is completely invisible.
+          expect(rect(records[0].boundingClientRect))
+              .to.eql(rect(documentElement.getBoundingClientRect()));
+          expect(rect(records[0].intersectionRect)).to.eql(emptyRect);
+          expect(records[0].isIntersecting).to.be(false);
+          expect(records[0].intersectionRatio).to.be(0);
+
+          // The document.body is completely invisible.
+          expect(rect(records[1].boundingClientRect))
+              .to.eql(rect(body.getBoundingClientRect()));
+          expect(rect(records[1].intersectionRect)).to.eql(emptyRect);
+          expect(records[1].isIntersecting).to.be(false);
+          expect(records[1].intersectionRatio).to.be(0);
+
+          // The target1 is completely invisible.
+          var clientRect1 = rect({
+            top: 0,
+            left: 0,
+            width: 100,
+            height: 200
+          });
+          expect(rect(records[2].boundingClientRect)).to.eql(clientRect1);
+          expect(rect(records[2].intersectionRect)).to.eql(emptyRect);
+          expect(records[2].isIntersecting).to.be(false);
+          expect(records[2].intersectionRatio).to.be(0);
+
+          done();
+          io.disconnect();
+        }, {}, parentRect);
+        io.observe(documentElement);
+        io.observe(body);
+        io.observe(iframeTargetEl1);
+      });
+
+      it('blocks until crossOriginUpdater is called first time', function(done) {
+        if (supportsNativeIntersectionObserver(iframeWin)) {
+          // Skip: not possible to emulate with the native observer.
+          done();
+          return;
+        }
+
+        var spy = sinon.spy();
+
+        var parentRect = rect({top: 0, left: 20, height: 300, width: 100});
+
+        var io = createObserver(spy, {});
+        io.observe(iframeTargetEl1);
+
+        runSequence([
+          function(done) {
+            setTimeout(function() {
+              expect(spy.callCount).to.be(0);
+
+              // Issue the first update.
+              crossOriginUpdater(parentRect, null);
+
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            setTimeout(function() {
+              expect(spy.callCount).to.be(1);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(1);
+              expect(records[0].intersectionRatio).to.be(0);
+              expect(records[0].isIntersecting).to.be(false);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            io.disconnect();
+            done();
+          }
+        ], done);
+      });
+
+      it('doesn\'t block with a root specified', function(done) {
+        var spy = sinon.spy();
+
+        var io = createObserver(spy, {root: body});
+        io.observe(iframeTargetEl1);
+
+        runSequence([
+          function(done) {
+            setTimeout(function() {
+              expect(spy.callCount).to.be(1);
+              var record = sortRecords(spy.lastCall.args[0])[0];
+              expect(record.intersectionRatio).to.be(1);
+              expect(record.isIntersecting).to.be(true);
+              expect(rect(record.rootBounds)).to.eql(rect(body.getBoundingClientRect()));
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            io.disconnect();
+            done();
+          }
+        ], done);
+      });
+
+      it('handles style changes', function(done) {
+        var spy = sinon.spy();
+
+        var parentRect = rect({top: 0, left: 0, height: 200, width: 100});
+
+        // When first element becomes invisible, the second element will show.
+        // And in reverse: when the first element becomes visible again, the
+        // second element will disappear.
+        var io = createObserver(spy, {}, parentRect);
+        io.observe(iframeTargetEl1);
+        io.observe(iframeTargetEl2);
+
+        runSequence([
+          function(done) {
+            setTimeout(function() {
+              expect(spy.callCount).to.be(1);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(2);
+              expect(records[0].intersectionRatio).to.be(1);
+              expect(records[0].isIntersecting).to.be(true);
+              expect(records[1].intersectionRatio).to.be(0);
+              expect(records[1].isIntersecting).to.be(false);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            iframeTargetEl1.style.display = 'none';
+            setTimeout(function() {
+              expect(spy.callCount).to.be(2);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(2);
+              expect(records[0].intersectionRatio).to.be(0);
+              expect(records[0].isIntersecting).to.be(false);
+              expect(records[1].intersectionRatio).to.be(1);
+              expect(records[1].isIntersecting).to.be(true);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            iframeTargetEl1.style.display = '';
+            setTimeout(function() {
+              expect(spy.callCount).to.be(3);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(2);
+              expect(records[0].intersectionRatio).to.be(1);
+              expect(records[0].isIntersecting).to.be(true);
+              expect(records[1].intersectionRatio).to.be(0);
+              expect(records[1].isIntersecting).to.be(false);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            io.disconnect();
+            done();
+          }
+        ], done);
+      });
+
+      it('handles scroll changes', function(done) {
+        var spy = sinon.spy();
+
+        var parentRect = rect({top: 0, left: 0, height: 200, width: 100});
+
+        // Scrolling to the middle of the iframe shows the second box and
+        // hides the first.
+        var io = createObserver(spy, {}, parentRect);
+        io.observe(iframeTargetEl1);
+        io.observe(iframeTargetEl2);
+
+        runSequence([
+          function(done) {
+            setTimeout(function() {
+              expect(spy.callCount).to.be(1);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(2);
+              expect(records[0].intersectionRatio).to.be(1);
+              expect(records[0].isIntersecting).to.be(true);
+              expect(records[1].intersectionRatio).to.be(0);
+              expect(records[1].isIntersecting).to.be(false);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            iframeWin.scrollTo(0, 202);
+            setTimeout(function() {
+              expect(spy.callCount).to.be(2);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(2);
+              expect(records[0].intersectionRatio).to.be(0);
+              expect(records[0].isIntersecting).to.be(false);
+              expect(records[1].intersectionRatio).to.be(1);
+              expect(records[1].isIntersecting).to.be(true);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            iframeWin.scrollTo(0, 0);
+            setTimeout(function() {
+              expect(spy.callCount).to.be(3);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(2);
+              expect(records[0].intersectionRatio).to.be(1);
+              expect(records[0].isIntersecting).to.be(true);
+              expect(records[1].intersectionRatio).to.be(0);
+              expect(records[1].isIntersecting).to.be(false);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            io.disconnect();
+            done();
+          }
+        ], done);
+      });
+
+      it('handles parent rect changes', function(done) {
+        var spy = sinon.spy();
+
+        var parentRect = rect({top: 0, left: 0, height: 200, width: 100});
+
+        // Iframe goes off screen and returns.
+        var io = createObserver(spy, {}, parentRect);
+        io.observe(iframeTargetEl1);
+        io.observe(iframeTargetEl2);
+
+        runSequence([
+          function(done) {
+            setTimeout(function() {
+              expect(spy.callCount).to.be(1);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(2);
+              checkRootBoundsAreNull(records);
+              expect(records[0].intersectionRatio).to.be(1);
+              expect(records[0].isIntersecting).to.be(true);
+              expect(records[1].intersectionRatio).to.be(0);
+              expect(records[1].isIntersecting).to.be(false);
+              // Top-level bounds.
+              expect(records[0].intersectionRect.height).to.be(200);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            // Completely off screen.
+            applyParentRect(rect({top: -202, left: 0, height: 200, width: 100}));
+            setTimeout(function() {
+              expect(spy.callCount).to.be(2);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(1);
+              checkRootBoundsAreNull(records);
+              expect(records[0].intersectionRatio).to.be(0);
+              expect(records[0].isIntersecting).to.be(false);
+              // Top-level bounds.
+              expect(records[0].intersectionRect.height).to.be(0);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            // Partially returns.
+            applyParentRect(rect({top: -100, left: 0, height: 200, width: 100}));
+            setTimeout(function() {
+              expect(spy.callCount).to.be(3);
+              var records = sortRecords(spy.lastCall.args[0]);
+              expect(records.length).to.be(1);
+              checkRootBoundsAreNull(records);
+              expect(records[0].intersectionRatio).to.be.within(0.45, 0.55);
+              expect(records[0].isIntersecting).to.be(true);
+              // Top-level bounds.
+              expect(records[0].intersectionRect.height / 200).to.be.within(0.45, 0.55);
+              done();
+            }, ASYNC_TIMEOUT);
+          },
+          function(done) {
+            io.disconnect();
+            done();
+          }
+        ], done);
+      });
     });
   });
 });
@@ -1618,11 +2371,13 @@ function runSequence(functions, done) {
 /**
  * Returns whether or not the current browser has native support for
  * IntersectionObserver.
+ * @param {Window=} win
  * @return {boolean} True if native support is detected.
  */
-function supportsNativeIntersectionObserver() {
-  return 'IntersectionObserver' in window &&
-      window.IntersectionObserver.toString().indexOf('[native code]') > -1;
+function supportsNativeIntersectionObserver(win) {
+  win = win || window;
+  return 'IntersectionObserver' in win &&
+      win.IntersectionObserver.toString().indexOf('[native code]') > -1;
 }
 
 

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -970,7 +970,8 @@ describe('IntersectionObserver', function() {
         iframeDoc.write('</style>');
         iframeDoc.close();
 
-        // Ensure the documentElement and body are always sorted on top.
+        // Ensure the documentElement and body are always sorted on top. See
+        // `sortRecords` for more info.
         documentElement = iframeDoc.documentElement;
         body = iframeDoc.body;
         documentElement.id = 'A1';

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -169,7 +169,7 @@ IntersectionObserver.prototype.USE_MUTATION_OBSERVER = true;
  * window, e.g. via messaging.
  * @return {function(DOMRect, DOMRect)}
  */
-IntersectionObserver.polyfillSetupCrossOriginUpdater = function() {
+IntersectionObserver._setupCrossOriginUpdater = function() {
   if (!crossOriginUpdater) {
     /**
      * @param {DOMRect} boundingClientRect
@@ -193,7 +193,7 @@ IntersectionObserver.polyfillSetupCrossOriginUpdater = function() {
 /**
  * Resets the cross-origin mode.
  */
-IntersectionObserver.polyfillResetCrossOriginUpdater = function() {
+IntersectionObserver._resetCrossOriginUpdater = function() {
   crossOriginUpdater = null;
   crossOriginRect = null;
 };

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -48,6 +48,20 @@ var document = window.document;
  */
 var registry = [];
 
+/**
+ * The signal updater for cross-origin intersection. When available, it means
+ * that the polyfill is configured to work in a cross-origin mode.
+ * @type {function(DOMRect, DOMRect)}
+ */
+var crossOriginUpdater = null;
+
+/**
+ * The current cross-origin intersection. Only available in the cross-origin
+ * mode.
+ * @type {DOMRect}
+ */
+var crossOriginRect = null;
+
 
 /**
  * Creates the global IntersectionObserverEntry constructor.
@@ -145,6 +159,45 @@ IntersectionObserver.prototype.POLL_INTERVAL = null;
  * to detect intersection changes.
  */
 IntersectionObserver.prototype.USE_MUTATION_OBSERVER = true;
+
+
+/**
+ * Set up the polyfill in the cross-origin mode. The result is the
+ * updater function that accepts two arguments: `boundingClientRect` and
+ * `intersectionRect` - just as these fields would be available to the
+ * parent via `IntersectionObserverEntry`. This function should be called
+ * each time the iframe receives intersection information from the parent
+ * window, e.g. via messaging.
+ * @return {function(DOMRect, DOMRect)}
+ */
+IntersectionObserver.polyfillSetupCrossOriginUpdater = function() {
+  if (!crossOriginUpdater) {
+    /**
+     * @param {DOMRect} boundingClientRect
+     * @param {DOMRect} intersectionRect
+     */
+    crossOriginUpdater = function(boundingClientRect, intersectionRect) {
+      if (!boundingClientRect || !intersectionRect) {
+        crossOriginRect = getEmptyRect();
+      } else {
+        crossOriginRect = convertFromParentRect(boundingClientRect, intersectionRect);
+      }
+      registry.forEach(function(observer) {
+        observer._checkForIntersections();
+      });
+    };
+  }
+  return crossOriginUpdater;
+};
+
+
+/**
+ * Resets the cross-origin mode.
+ */
+IntersectionObserver.polyfillResetCrossOriginUpdater = function() {
+  crossOriginUpdater = null;
+  crossOriginRect = null;
+};
 
 
 /**
@@ -405,6 +458,11 @@ IntersectionObserver.prototype._unmonitorAllIntersections = function() {
  * @private
  */
 IntersectionObserver.prototype._checkForIntersections = function() {
+  if (!this.root && crossOriginUpdater && !crossOriginRect) {
+    // Cross origin monitoring, but no initial data available yet.
+    return;
+  }
+
   var rootIsInDom = this._rootIsInDom();
   var rootRect = rootIsInDom ? this._getRootRect() : getEmptyRect();
 
@@ -420,7 +478,7 @@ IntersectionObserver.prototype._checkForIntersections = function() {
       time: now(),
       target: target,
       boundingClientRect: targetRect,
-      rootBounds: rootRect,
+      rootBounds: crossOriginUpdater && !this.root ? null : rootRect,
       intersectionRect: intersectionRect
     });
 
@@ -481,7 +539,19 @@ IntersectionObserver.prototype._computeTargetAndRootIntersection =
     if (parent == this.root || parent.nodeType == /* DOCUMENT */ 9) {
       atRoot = true;
       if (parent == this.root || parent == document) {
-        parentRect = rootRect;
+        if (crossOriginUpdater && !this.root) {
+          if (!crossOriginRect ||
+              crossOriginRect.width == 0 && crossOriginRect.height == 0) {
+            // A 0-size cross-origin intersection means no-intersection.
+            parent = null;
+            parentRect = null;
+            intersectionRect = null;
+          } else {
+            parentRect = crossOriginRect;
+          }
+        } else {
+          parentRect = rootRect;
+        }
       } else {
         // Check if there's a frame that can be navigated to.
         var frame = getParentNode(parent);
@@ -532,6 +602,7 @@ IntersectionObserver.prototype._getRootRect = function() {
   if (this.root) {
     rootRect = getBoundingClientRect(this.root);
   } else {
+
     // Use <html>/<body> instead of window since scroll bars affect size.
     var html = document.documentElement;
     var body = document.body;

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -602,7 +602,6 @@ IntersectionObserver.prototype._getRootRect = function() {
   if (this.root) {
     rootRect = getBoundingClientRect(this.root);
   } else {
-
     // Use <html>/<body> instead of window since scroll bars affect size.
     var html = document.documentElement;
     var body = document.body;

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -49,15 +49,14 @@ var document = window.document;
 var registry = [];
 
 /**
- * The signal updater for cross-origin intersection. When available, it means
+ * The signal updater for cross-origin intersection. When not null, it means
  * that the polyfill is configured to work in a cross-origin mode.
  * @type {function(DOMRect, DOMRect)}
  */
 var crossOriginUpdater = null;
 
 /**
- * The current cross-origin intersection. Only available in the cross-origin
- * mode.
+ * The current cross-origin intersection. Only used in the cross-origin mode.
  * @type {DOMRect}
  */
 var crossOriginRect = null;
@@ -162,7 +161,7 @@ IntersectionObserver.prototype.USE_MUTATION_OBSERVER = true;
 
 
 /**
- * Set up the polyfill in the cross-origin mode. The result is the
+ * Sets up the polyfill in the cross-origin mode. The result is the
  * updater function that accepts two arguments: `boundingClientRect` and
  * `intersectionRect` - just as these fields would be available to the
  * parent via `IntersectionObserverEntry`. This function should be called


### PR DESCRIPTION
This pull request enables the polyfill to support cross-origin intersection observer features, assuming the host page messages the correct intersection information.