### PR TITLE
Polyfill: ensure the complete DOMRect shape is returned

### DIFF
--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -157,6 +157,21 @@ describe('IntersectionObserver', function() {
       }).to.throwException();
     });
 
+    it('fills in x and y in the resulting rects', function(done) {
+      io = new IntersectionObserver(function(records) {
+        expect(records.length).to.be(1);
+        var entry = records[0];
+        expect(entry.rootBounds.x).to.be(entry.rootBounds.left);
+        expect(entry.rootBounds.y).to.be(entry.rootBounds.top);
+        expect(entry.boundingClientRect.x).to.be(entry.boundingClientRect.left);
+        expect(entry.boundingClientRect.y).to.be(entry.boundingClientRect.top);
+        expect(entry.intersectionRect.x).to.be(entry.intersectionRect.left);
+        expect(entry.intersectionRect.y).to.be(entry.intersectionRect.top);
+        done();
+      }, {root: rootEl});
+      targetEl2.style.top = '-40px';
+      io.observe(targetEl1);
+    });
 
     it('triggers for all targets when observing begins', function(done) {
       io = new IntersectionObserver(function(records) {
@@ -1000,6 +1015,8 @@ describe('IntersectionObserver', function() {
 
     function rect(r) {
       return {
+        y: typeof r.y == 'number' ? r.y : r.top,
+        x: typeof r.x == 'number' ? r.x : r.left,
         top: r.top,
         left: r.left,
         width: r.width != null ? r.width : r.right - r.left,

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -71,9 +71,9 @@ var crossOriginRect = null;
 function IntersectionObserverEntry(entry) {
   this.time = entry.time;
   this.target = entry.target;
-  this.rootBounds = entry.rootBounds;
-  this.boundingClientRect = entry.boundingClientRect;
-  this.intersectionRect = entry.intersectionRect || getEmptyRect();
+  this.rootBounds = fixDOMRect(entry.rootBounds);
+  this.boundingClientRect = fixDOMRect(entry.boundingClientRect);
+  this.intersectionRect = fixDOMRect(entry.intersectionRect || getEmptyRect());
   this.isIntersecting = !!entry.intersectionRect;
 
   // Calculates the intersection ratio.
@@ -859,6 +859,30 @@ function getEmptyRect() {
     right: 0,
     width: 0,
     height: 0
+  };
+}
+
+
+/**
+ * Ensure that the result has all of the necessary fields of the DOMRect.
+ * Specifically this ensures that `x` and `y` fields are set.
+ *
+ * @param {?DOMRect} rect
+ * @return {?DOMRect}
+ */
+function fixDOMRect(rect) {
+  if (!rect || 'x' in rect) {
+    return rect;
+  }
+  return {
+    top: rect.top,
+    y: rect.top,
+    bottom: rect.bottom,
+    left: rect.left,
+    x: rect.left,
+    right: rect.right,
+    width: rect.width,
+    height: rect.height
   };
 }
 

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intersection-observer",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A polyfill for IntersectionObserver",
   "main": "intersection-observer",
   "repository": {


### PR DESCRIPTION
Context:

* Most of browsers use `DOMRect` structure with the shape `{x, y, top, left, width, height, bottom, right}`. The `x` and `y` simply mirror `top` and `left` when `width` and `height` are positive, which should be the case for us always.
* IE has its own `ClientRect` with the same `{top, left, width, height, bottom, right}`.
* I believe the polyfill always uses the native result of the `getBoundingClientRect()` for `Entry.boundingClientRect`. However it calculates `rootBounds` and `intersectionRect` fields.
* Consequently, I think the biggest possible source of compatibility issues is for the fields we calculate that currently always miss `x` and `y`. For instance [this computation](https://github.com/w3c/IntersectionObserver/blob/9bb05eaf228d98d807f20006cfa8de1dcc56850b/polyfill/intersection-observer.js#L806). Or event a simple [getEmptyRect](https://github.com/w3c/IntersectionObserver/blob/9bb05eaf228d98d807f20006cfa8de1dcc56850b/polyfill/intersection-observer.js#L854).
* Thus, on the platforms that support `DOMRect`, we definitely have an inconsistency, since the `boundingClientRect` has `x/y` and the other two rects do not.

I could have updated only the polyfill calculations only. But for consistency, I decided to just update "fill in" x/y in all rects returned by the `IntersectionObserverEntry`.
