### PR TITLE
Fix same-origin polyfill to work the same way when loaded from iframe as from mainframe

### DIFF
--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -33,12 +33,32 @@ if ('IntersectionObserver' in window &&
   return;
 }
 
+/**
+ * Returns the embedding frame element, if any.
+ * @param {!Document} doc
+ * @return {!Element}
+ */
+function getFrameElement(doc) {
+  try {
+    return doc.defaultView && doc.defaultView.frameElement || null;
+  } catch (e) {
+    // Ignore the error.
+    return null;
+  }
+}
 
 /**
- * A local reference to the document.
+ * A local reference to the root document.
  */
-var document = window.document;
-
+var document = (function(startDoc) {
+  var doc = startDoc;
+  var frame = getFrameElement(doc);
+  while (frame) {
+    doc = frame.ownerDocument;
+    frame = getFrameElement(doc);
+  }
+  return doc;
+})(window.document);
 
 /**
  * An IntersectionObserver registry. This registry exists to hold a strong
@@ -956,21 +976,6 @@ function getParentNode(node) {
   }
 
   return parent;
-}
-
-
-/**
- * Returns the embedding frame element, if any.
- * @param {!Document} doc
- * @return {!Element}
- */
-function getFrameElement(doc) {
-  try {
-    return doc.defaultView && doc.defaultView.frameElement || null;
-  } catch (e) {
-    // Ignore the error.
-    return null;
-  }
 }
 
 


### PR DESCRIPTION
It shouldn't matter whether from the same-origin iframe point of view whether the polyfill was loaded in the mainframe or subframe: they should work the same in terms of `rootBounds` and all other logic.

E.g. the following snippets should work similar from the point of view of most of Intersection Observer API when observing the element `<div id=one>`:

```
<script src=".../polyfill.js"></script>
<iframe srcdoc="<div id=one></div>"></iframe>
```

```
<iframe srcdoc="<script src=".../polyfill.js"></script><div id=one></div>"></iframe>
```
