### PR TITLE
Remove references to unit of related similar-origin browsing contexts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -26,11 +26,11 @@ urlPrefix: https://html.spec.whatwg.org/multipage/
 	urlPrefix: dom.html
 		url: #the-document-object; type:dfn; text: Document
 	urlPrefix: browsers.html
-		type: dfn; text: unit of related similar-origin browsing contexts
 		type: dfn; text: browsing context
 		type: dfn; text: top-level browsing context
 		type: dfn; text: nested browsing contexts
 		type: dfn; text: browsing context container
+		type: dfn; text: browsing context scope origin
 		type: dfn; text: fully active
 	urlPrefix: webappapis.html;
 		type: dfn; text: report the exception
@@ -49,6 +49,7 @@ urlPrefix: https://heycam.github.io/webidl/
 		text: SyntaxError
 	urlPrefix: #dfn-; type:dfn; text: throw
 	urlPrefix: #idl-; type:interface; text: double
+	urlPrefix: #idl-; type:interface; text: undefined
 	url: #hierarchyrequesterror; type: exception; text: HierarchyRequestError
 urlPrefix: https://drafts.csswg.org/css-box/
 	url: #containing-block; type: dfn; text: containing block
@@ -278,9 +279,9 @@ interface IntersectionObserver {
 	::
 		Offsets applied to the <a>root intersection rectangle</a>,
 		effectively growing or shrinking the box that is used to calculate intersections.
-		Note that {{IntersectionObserver/rootMargin}} is only applied
-		for <a>targets</a> which belong to the same <a>unit of related similar-origin browsing contexts</a>
-		as the <a>intersection root</a>.
+		Note that for <a>implicit root</a> observers,
+		{{IntersectionObserver/rootMargin}} is only applied
+		for <a>targets</a> which have a <a>browsing context scope origin</a>.
 
 		On getting, return the result of serializing the elements of {{[[rootMargin]]}}
 		space-separated, where pixel lengths serialize as the numeric value followed by "px",
@@ -323,8 +324,9 @@ is the rectangle we'll use to check against the targets.
 	<dd>it's the result of running the {{Element/getBoundingClientRect()}} algorithm on the <a>intersection root</a>.
 </dl>
 
-For any <a>target</a> which belongs to the same <a>unit of related similar-origin browsing contexts</a>
-as the <a>intersection root</a>,
+If the <a>intersection root</a> is not the <a>implicit root</a>,
+or when calculating the <a>intersection root</a> for
+a <a>target</a> which has a <a>browsing context scope origin</a>,
 the rectangle is then expanded
 according to the offsets in the {{IntersectionObserver}}’s {{[[rootMargin]]}} slot
 in a manner similar to CSS's 'margin' property,
@@ -426,9 +428,9 @@ dictionary IntersectionObserverEntryInit {
 		1 if the {{IntersectionObserverEntry/isIntersecting}} is true, and 0 if not.
 	: <dfn>rootBounds</dfn>
 	::
-		If {{IntersectionObserverEntry/target}} belongs to the same
-		<a>unit of related similar-origin browsing contexts</a>
-		as the <a>intersection root</a>,
+		If the {{IntersectionObserver}} is not an <a>implicit root</a> observer,
+		or if the {{IntersectionObserverEntry/target}} has a
+		<a>browsing context scope origin</a>,
 		this will be the <a>root intersection rectangle</a>.
 		Otherwise, this will be <code>null</code>.
 		Note that if the target is in a different <a>browsing context</a> than the <a>intersection root</a>,

--- a/index.bs
+++ b/index.bs
@@ -279,7 +279,7 @@ interface IntersectionObserver {
 	::
 		Offsets applied to the <a>root intersection rectangle</a>,
 		effectively growing or shrinking the box that is used to calculate intersections.
-		Note that for <a>implicit root</a> observers,
+		Note that for <a>implicit root observer</a>s,
 		{{IntersectionObserver/rootMargin}} is only applied
 		for <a>targets</a> which have a <a>browsing context scope origin</a>.
 
@@ -305,13 +305,16 @@ for an {{IntersectionObserver}} is the value of its {{IntersectionObserver/root}
 or else the <a>top-level browsing context</a>'s {{document}} node
 (referred to as the <dfn for="IntersectionObserver">implicit root</dfn>) if
 the {{IntersectionObserver/root}} attribute is <code>null</code>.
+An {{IntersectionObserver}} whose <a>intersection root</a> is the <a>implicit root</a>
+is referred to as an <dfn for="IntersectionObserver">implicit root observer</dfn>;
+otherwise, it's an <dfn for="IntersectionObserver">explicit root observer</dfn>.
 
 The <dfn for=IntersectionObserver>root intersection rectangle</dfn>
 for an {{IntersectionObserver}}
 is the rectangle we'll use to check against the targets.
 
 <dl class=switch>
-	<dt>If the <a>intersection root</a> is the <a>implicit root</a>,
+	<dt>If the the {{IntersectionObserver}} is an <a>implicit root observer</a>,
 	<dd>it's treated as if the root were the <a>top-level browsing context</a>'s {{document}}, according to the following rule for {{document}}.
 
 	<dt>If the <a>intersection root</a> is a {{document}},
@@ -324,7 +327,7 @@ is the rectangle we'll use to check against the targets.
 	<dd>it's the result of running the {{Element/getBoundingClientRect()}} algorithm on the <a>intersection root</a>.
 </dl>
 
-If the <a>intersection root</a> is not the <a>implicit root</a>,
+If the {{IntersectionObserver}} is an <a>explicit root observer</a>,
 or when calculating the <a>intersection root</a> for
 a <a>target</a> which has a <a>browsing context scope origin</a>,
 the rectangle is then expanded
@@ -428,7 +431,7 @@ dictionary IntersectionObserverEntryInit {
 		1 if the {{IntersectionObserverEntry/isIntersecting}} is true, and 0 if not.
 	: <dfn>rootBounds</dfn>
 	::
-		If the {{IntersectionObserver}} is not an <a>implicit root</a> observer,
+		If the {{IntersectionObserver}} is not an <a>implicit root observer</a>,
 		or if the {{IntersectionObserverEntry/target}} has a
 		<a>browsing context scope origin</a>,
 		this will be the <a>root intersection rectangle</a>.
@@ -613,7 +616,7 @@ To <dfn>run the update intersection observations steps</dfn> for a
 
 1. Let |observer list| be a list of all {{IntersectionObserver}}s
 	whose {{IntersectionObserver/root}} is in the DOM tree of |document|.
-	For the <a>top-level browsing context</a>, this includes <a>implicit root</a> observers.
+	For the <a>top-level browsing context</a>, this includes <a>implicit root observer</a>s.
 2. For each |observer| in |observer list|:
 	1. Let |rootBounds| be |observer|'s <a>root intersection rectangle</a>.
 	2. For each |target| in |observer|'s internal {{[[ObservationTargets]]}} slot, processed in the same order that {{observe()}} was called on each |target|:
@@ -686,7 +689,7 @@ A {{document}} is said to have <dfn>pending initial IntersectionObserver targets
 if there is at least one {{IntersectionObserver}} meeting these criteria:
 	<ol>
 		<li>The |observer|'s {{IntersectionObserver|root}} is in the |document|
-		   (for the <a>top-level browsing context</a>, this includes <a>implicit root</a> observers).
+		   (for the <a>top-level browsing context</a>, this includes <a>implicit root observer</a>s).
 		</li>
 		<li>The |observer| has at least one |target| in its {{[[ObservationTargets]]}} slot for which
 		    no {{IntersectionObserverEntry}} has yet been queued.

--- a/index.bs
+++ b/index.bs
@@ -192,7 +192,7 @@ any {{Element}} in the <a>top-level browsing context</a>,
 as well as any {{Element}} in any <a>nested browsing context</a>
 which is in the <a>list of the descendant browsing contexts</a> of the <a>top-level browsing context</a>.
 
-When dealing with <a>implicit root observer</a>s, the API makes a distinction between
+When dealing with <a>implicit root observers</a>, the API makes a distinction between
 a <a>target</a> whose <a>relevant settings object</a>'s <a>origin</a> is
 <a>same origin-domain</a> with the <a>top-level origin</a>, referred to as a
 <dfn for="IntersectionObserver">same-origin target</dfn>;
@@ -322,7 +322,7 @@ for an {{IntersectionObserver}}
 is the rectangle we'll use to check against the targets.
 
 <dl class=switch>
-	<dt>If the the {{IntersectionObserver}} is an <a>implicit root observer</a>,
+	<dt>If the {{IntersectionObserver}} is an <a>implicit root observer</a>,
 	<dd>it's treated as if the root were the <a>top-level browsing context</a>'s {{document}}, according to the following rule for {{document}}.
 
 	<dt>If the <a>intersection root</a> is a {{document}},
@@ -619,7 +619,7 @@ To <dfn>run the update intersection observations steps</dfn> for a
 
 1. Let |observer list| be a list of all {{IntersectionObserver}}s
 	whose {{IntersectionObserver/root}} is in the DOM tree of |document|.
-	For the <a>top-level browsing context</a>, this includes <a>implicit root observer</a>s.
+	For the <a>top-level browsing context</a>, this includes <a>implicit root observers</a>.
 2. For each |observer| in |observer list|:
 	1. Let |rootBounds| be |observer|'s <a>root intersection rectangle</a>.
 	2. For each |target| in |observer|'s internal {{[[ObservationTargets]]}} slot, processed in the same order that {{observe()}} was called on each |target|:
@@ -692,7 +692,7 @@ A {{document}} is said to have <dfn>pending initial IntersectionObserver targets
 if there is at least one {{IntersectionObserver}} meeting these criteria:
 	<ol>
 		<li>The |observer|'s {{IntersectionObserver|root}} is in the |document|
-		   (for the <a>top-level browsing context</a>, this includes <a>implicit root observer</a>s).
+		   (for the <a>top-level browsing context</a>, this includes <a>implicit root observers</a>).
 		</li>
 		<li>The |observer| has at least one |target| in its {{[[ObservationTargets]]}} slot for which
 		    no {{IntersectionObserverEntry}} has yet been queued.

--- a/index.bs
+++ b/index.bs
@@ -177,15 +177,15 @@ intersection of an <a>intersection root</a> and one or more <a>target</a> {{Elem
 
 The <dfn for="IntersectionObserver">intersection root</dfn>
 for an {{IntersectionObserver}} is the value of its {{IntersectionObserver/root}} attribute
-if the attribute is non-null;
+if the attribute is non-<code>null</code>;
 otherwise, it is the <a>top-level browsing context</a>'s {{document}} node,
 referred to as the <dfn for="IntersectionObserver">implicit root</dfn>.
 
-An {{IntersectionObserver}} with a non-null {{IntersectionObserver/root}}
+An {{IntersectionObserver}} with a non-<code>null</code> {{IntersectionObserver/root}}
 is referred to as an <dfn for="IntersectionObserver">explicit root observer</dfn>,
 and it can observe any <a>target</a> {{Element}} that is a descendant of the
 {{IntersectionObserver/root}} in the <a>containing block chain</a>.
-An {{IntersectionObserver}} with a null {{IntersectionObserver/root}}
+An {{IntersectionObserver}} with a <code>null</code> {{IntersectionObserver/root}}
 is referred to as an <dfn for="IntersectionObserver">implicit root observer</dfn>.
 Valid <a>targets</a> for an <a>implicit root observer</a> include
 any {{Element}} in the <a>top-level browsing context</a>,

--- a/index.bs
+++ b/index.bs
@@ -28,9 +28,9 @@ urlPrefix: https://html.spec.whatwg.org/multipage/
 	urlPrefix: browsers.html
 		type: dfn; text: browsing context
 		type: dfn; text: top-level browsing context
-		type: dfn; text: nested browsing contexts
+		type: dfn; text: nested browsing context
+		type: dfn; text: list of the descendant browsing contexts
 		type: dfn; text: browsing context container
-		type: dfn; text: browsing context scope origin
 		type: dfn; text: fully active
 	urlPrefix: webappapis.html;
 		type: dfn; text: report the exception
@@ -38,10 +38,14 @@ urlPrefix: https://html.spec.whatwg.org/multipage/
 		type: dfn; text: queue a task
 		type: dfn; text: run the fullscreen rendering steps
 		type: dfn; text: run the animation frame callbacks
+		type: dfn; text: relevant settings object
 		url: #event-loop-processing-model; type: dfn; text: HTML Processing Model
+		url: #concept-environment-top-level-origin; type: dfn; text: top-level origin
 	urlPrefix: infrastructure.html;
 		type: dfn; text: rules for parsing dimension values
 		url: #dfn-callback-this-value; type: dfn; text: callback this value
+	urlPrefix: origin.html
+		type: dfn; text: origin
 urlPrefix: https://heycam.github.io/webidl/
 	url: #dfn-simple-exception; type:exception;
 		text: RangeError
@@ -171,15 +175,31 @@ The IntersectionObserver interface</h3>
 The {{IntersectionObserver}} interface can be used to observe changes in the
 intersection of an <a>intersection root</a> and one or more <a>target</a> {{Element}}s.
 
-An {{IntersectionObserver}} with a {{IntersectionObserver/root}} {{Node}} can
-observe any <a>target</a> {{Element}} that is a descendant of the
-{{IntersectionObserver/root}} in the <a>containing block chain</a>.
+The <dfn for="IntersectionObserver">intersection root</dfn>
+for an {{IntersectionObserver}} is the value of its {{IntersectionObserver/root}} attribute
+if the attribute is non-null;
+otherwise, it is the <a>top-level browsing context</a>'s {{document}} node,
+referred to as the <dfn for="IntersectionObserver">implicit root</dfn>.
 
-An {{IntersectionObserver}} with no {{IntersectionObserver/root}} {{Node}}
-will automatically observe intersections with the <a>implicit root</a>,
-and valid <a>targets</a> include any {{Element}} in the
-<a>top-level browsing context</a>, as well as any {{Element}} in any
-<a>nested browsing contexts</a> inside the <a>top-level browsing context</a>.
+An {{IntersectionObserver}} with a non-null {{IntersectionObserver/root}}
+is referred to as an <dfn for="IntersectionObserver">explicit root observer</dfn>,
+and it can observe any <a>target</a> {{Element}} that is a descendant of the
+{{IntersectionObserver/root}} in the <a>containing block chain</a>.
+An {{IntersectionObserver}} with a null {{IntersectionObserver/root}}
+is referred to as an <dfn for="IntersectionObserver">implicit root observer</dfn>.
+Valid <a>targets</a> for an <a>implicit root observer</a> include
+any {{Element}} in the <a>top-level browsing context</a>,
+as well as any {{Element}} in any <a>nested browsing context</a>
+which is in the <a>list of the descendant browsing contexts</a> of the <a>top-level browsing context</a>.
+
+When dealing with <a>implicit root observer</a>s, the API makes a distinction between
+a <a>target</a> whose <a>relevant settings object</a>'s <a>origin</a> is
+<a>same origin-domain</a> with the <a>top-level origin</a>, referred to as a
+<dfn for="IntersectionObserver">same-origin target</dfn>;
+as opposed to a <dfn for="IntersectionObserver">cross-origin target</dfn>.
+Any <a>target</a> of an <a>explicit root observer</a> is also a <a>same-origin target</a>,
+since the <a>target</a> must be in the same <a>document</a> as the
+<a>intersection root</a>.
 
 Note: In {{MutationObserver}}, the {{MutationObserverInit}} options are passed
 to {{MutationObserver/observe()}} while in {{IntersectionObserver}} they are
@@ -188,11 +208,9 @@ being observed could have a different set of attributes to filter for. For
 {{IntersectionObserver}}, developers may choose to use a single observer to
 track multiple targets using the same set of options; or they may use a different
 observer for each tracked target.
-
 {{IntersectionObserverInit/rootMargin}} or {{threshold}} values for each
 <a>target</a> seems to introduce more complexity without solving additional
-use-cases. Per-{{observe()}} options could be provided in the future if V2
-introduces a need for it.
+use-cases. Per-{{observe()}} options could be provided in the future if the need arises.
 
 <pre class="idl">
 [Exposed=Window]
@@ -279,9 +297,8 @@ interface IntersectionObserver {
 	::
 		Offsets applied to the <a>root intersection rectangle</a>,
 		effectively growing or shrinking the box that is used to calculate intersections.
-		Note that for <a>implicit root observer</a>s,
-		{{IntersectionObserver/rootMargin}} is only applied
-		for <a>targets</a> which have a <a>browsing context scope origin</a>.
+		<b>These offsets are only applied when handling <a>same-origin targets</a>;
+		for <a>cross-origin targets</a> they are ignored.</b>
 
 		On getting, return the result of serializing the elements of {{[[rootMargin]]}}
 		space-separated, where pixel lengths serialize as the numeric value followed by "px",
@@ -299,15 +316,6 @@ interface IntersectionObserver {
 		If no |options|.{{IntersectionObserverInit/threshold}} was provided to the
 		{{IntersectionObserver}} constructor, the value of this attribute will be [0].
 </div>
-
-The <dfn for="IntersectionObserver">intersection root</dfn>
-for an {{IntersectionObserver}} is the value of its {{IntersectionObserver/root}} attribute,
-or else the <a>top-level browsing context</a>'s {{document}} node
-(referred to as the <dfn for="IntersectionObserver">implicit root</dfn>) if
-the {{IntersectionObserver/root}} attribute is <code>null</code>.
-An {{IntersectionObserver}} whose <a>intersection root</a> is the <a>implicit root</a>
-is referred to as an <dfn for="IntersectionObserver">implicit root observer</dfn>;
-otherwise, it's an <dfn for="IntersectionObserver">explicit root observer</dfn>.
 
 The <dfn for=IntersectionObserver>root intersection rectangle</dfn>
 for an {{IntersectionObserver}}
@@ -327,10 +335,8 @@ is the rectangle we'll use to check against the targets.
 	<dd>it's the result of running the {{Element/getBoundingClientRect()}} algorithm on the <a>intersection root</a>.
 </dl>
 
-If the {{IntersectionObserver}} is an <a>explicit root observer</a>,
-or when calculating the <a>intersection root</a> for
-a <a>target</a> which has a <a>browsing context scope origin</a>,
-the rectangle is then expanded
+When calculating the <a>root intersection rectangle</a> for
+a <a>same-origin target</a>, the rectangle is then expanded
 according to the offsets in the {{IntersectionObserver}}’s {{[[rootMargin]]}} slot
 in a manner similar to CSS's 'margin' property,
 with the four values indicating the amount the top, right, bottom, and left edges, respectively, are offset by,
@@ -431,10 +437,7 @@ dictionary IntersectionObserverEntryInit {
 		1 if the {{IntersectionObserverEntry/isIntersecting}} is true, and 0 if not.
 	: <dfn>rootBounds</dfn>
 	::
-		If the {{IntersectionObserver}} is not an <a>implicit root observer</a>,
-		or if the {{IntersectionObserverEntry/target}} has a
-		<a>browsing context scope origin</a>,
-		this will be the <a>root intersection rectangle</a>.
+		For a <a>same-origin target</a>, this will be the <a>root intersection rectangle</a>.
 		Otherwise, this will be <code>null</code>.
 		Note that if the target is in a different <a>browsing context</a> than the <a>intersection root</a>,
 		this will be in a different coordinate system

--- a/index.bs
+++ b/index.bs
@@ -195,9 +195,9 @@ which is in the <a>list of the descendant browsing contexts</a> of the <a>top-le
 When dealing with <a>implicit root observers</a>, the API makes a distinction between
 a <a>target</a> whose <a>relevant settings object</a>'s <a>origin</a> is
 <a>same origin-domain</a> with the <a>top-level origin</a>, referred to as a
-<dfn for="IntersectionObserver">same-origin target</dfn>;
-as opposed to a <dfn for="IntersectionObserver">cross-origin target</dfn>.
-Any <a>target</a> of an <a>explicit root observer</a> is also a <a>same-origin target</a>,
+<dfn for="IntersectionObserver">same-origin-domain target</dfn>;
+as opposed to a <dfn for="IntersectionObserver">cross-origin-domain target</dfn>.
+Any <a>target</a> of an <a>explicit root observer</a> is also a <a>same-origin-domain target</a>,
 since the <a>target</a> must be in the same <a>document</a> as the
 <a>intersection root</a>.
 
@@ -297,8 +297,8 @@ interface IntersectionObserver {
 	::
 		Offsets applied to the <a>root intersection rectangle</a>,
 		effectively growing or shrinking the box that is used to calculate intersections.
-		<b>These offsets are only applied when handling <a>same-origin targets</a>;
-		for <a>cross-origin targets</a> they are ignored.</b>
+		<b>These offsets are only applied when handling <a>same-origin-domain targets</a>;
+		for <a>cross-origin-domain targets</a> they are ignored.</b>
 
 		On getting, return the result of serializing the elements of {{[[rootMargin]]}}
 		space-separated, where pixel lengths serialize as the numeric value followed by "px",
@@ -336,7 +336,7 @@ is the rectangle we'll use to check against the targets.
 </dl>
 
 When calculating the <a>root intersection rectangle</a> for
-a <a>same-origin target</a>, the rectangle is then expanded
+a <a>same-origin-domain target</a>, the rectangle is then expanded
 according to the offsets in the {{IntersectionObserver}}’s {{[[rootMargin]]}} slot
 in a manner similar to CSS's 'margin' property,
 with the four values indicating the amount the top, right, bottom, and left edges, respectively, are offset by,
@@ -437,7 +437,7 @@ dictionary IntersectionObserverEntryInit {
 		1 if the {{IntersectionObserverEntry/isIntersecting}} is true, and 0 if not.
 	: <dfn>rootBounds</dfn>
 	::
-		For a <a>same-origin target</a>, this will be the <a>root intersection rectangle</a>.
+		For a <a>same-origin-domain target</a>, this will be the <a>root intersection rectangle</a>.
 		Otherwise, this will be <code>null</code>.
 		Note that if the target is in a different <a>browsing context</a> than the <a>intersection root</a>,
 		this will be in a different coordinate system


### PR DESCRIPTION
Closes #429


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/pull/448.html" title="Last updated on Sep 19, 2020, 5:29 PM UTC (604c60b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/448/f71dad4...604c60b.html" title="Last updated on Sep 19, 2020, 5:29 PM UTC (604c60b)">Diff</a>