### PR TITLE
Fix spec link for document

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -24,7 +24,7 @@ urlPrefix: http://www.w3.org/TR/hr-time/
 	type: dfn; text: time origin
 urlPrefix: https://html.spec.whatwg.org/multipage/
 	urlPrefix: dom.html
-		url: #the-document-object; type:dfn; text: Document
+		url: #document; type:dfn; text: Document
 	urlPrefix: browsers.html
 		type: dfn; text: browsing context
 		type: dfn; text: top-level browsing context


### PR DESCRIPTION
Closes #416


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/pull/451.html" title="Last updated on Sep 23, 2020, 7:04 PM UTC (2977a0b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/451/4c53ab2...2977a0b.html" title="Last updated on Sep 23, 2020, 7:04 PM UTC (2977a0b)">Diff</a>