### PR TITLE
Allow 0 (without unit) as a valid offset for rootMargin

### DIFF
--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -91,7 +91,7 @@ describe('IntersectionObserver', function() {
       io = new IntersectionObserver(noop, {rootMargin: '10px 20% 0px'});
       expect(io.rootMargin).to.be('10px 20% 0px 20%');
 
-      io = new IntersectionObserver(noop, {rootMargin: '0px 0px -5% 5px'});
+      io = new IntersectionObserver(noop, {rootMargin: '0px 0 -5% 5px'});
       expect(io.rootMargin).to.be('0px 0px -5% 5px');
 
       // TODO(philipwalton): the polyfill supports fractional pixel and

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -319,6 +319,9 @@ IntersectionObserver.prototype._initThresholds = function(opt_threshold) {
 IntersectionObserver.prototype._parseRootMargin = function(opt_rootMargin) {
   var marginString = opt_rootMargin || '0px';
   var margins = marginString.split(/\s+/).map(function(margin) {
+    if (margin === '0') {
+      return {value: 0, unit: 'px'};
+    }
     var parts = /^(-?\d*\.?\d+)(px|%)$/.exec(margin);
     if (!parts) {
       throw new Error('rootMargin must be specified in pixels or percent');


### PR DESCRIPTION
Closes #244 

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
