### PR TITLE
Support iframe viewport tracking

### DIFF
--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -69,12 +69,15 @@ describe('IntersectionObserver', function() {
       io = new IntersectionObserver(noop);
       expect(io.root).to.be(null);
 
+      io = new IntersectionObserver(noop, {root: document});
+      expect(io.root).to.be(document);
+
       io = new IntersectionObserver(noop, {root: rootEl});
-      expect(io.root).to.be(rootEl);
+      expect(io.root).to.be(rootEl); 
     });
 
 
-    it('throws when root is not an Element', function() {
+    it('throws when root is not a Document or Element', function() {
       expect(function() {
         io = new IntersectionObserver(noop, {root: 'foo'});
       }).to.throwException();

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -1401,6 +1401,31 @@ describe('IntersectionObserver', function() {
         io.observe(iframeTargetEl2);
       });
 
+      it('handles tracking iframe viewport', function(done) {
+        iframe.style.height = '100px';
+        // {root:iframeDoc} means to track the iframe viewport irrespective of toplevel viewport
+        var io = new IntersectionObserver(
+          function (records) {
+            var subviewportWidth =
+              iframeDoc.documentElement.clientWidth || iframeDoc.body.clientWidth;
+            var subviewportHeight =
+              iframeDoc.documentElement.clientHeight || iframeDoc.body.clientHeight;
+
+            expect(records.length).to.be(1);
+            expect(records[0].rootBounds.top).to.be(0);
+            expect(records[0].rootBounds.left).to.be(0);
+            expect(records[0].rootBounds.right).to.be(subviewportWidth);
+            expect(records[0].rootBounds.width).to.be(subviewportWidth);
+            expect(records[0].rootBounds.bottom).to.be(subviewportHeight);
+            expect(records[0].rootBounds.height).to.be(subviewportHeight);
+            done();
+          },
+          { root: iframeDoc }
+        );
+
+        io.observe(iframeTargetEl1);
+      });
+
       it('handles style changes', function(done) {
         var spy = sinon.spy();
 
@@ -1627,10 +1652,10 @@ describe('IntersectionObserver', function() {
       var ASYNC_TIMEOUT = 300;
 
       beforeEach(function(done) {
-        /* Uncomment these lines to force polyfill inside the iframe.
+        // /* Uncomment these lines to force polyfill inside the iframe.
         delete iframeWin.IntersectionObserver;
         delete iframeWin.IntersectionObserverEntry;
-        */
+        // */
 
         // Install polyfill right into the iframe.
         if (!iframeWin.IntersectionObserver) {
@@ -2290,10 +2315,10 @@ describe('IntersectionObserver', function() {
       beforeEach(function(done) {
         Object.defineProperty(iframeWin, 'frameElement', {value: null});
 
-        /* Uncomment these lines to force polyfill inside the iframe.
+        // /* Uncomment these lines to force polyfill inside the iframe.
         delete iframeWin.IntersectionObserver;
         delete iframeWin.IntersectionObserverEntry;
-        */
+        // */
 
         // Install polyfill right into the iframe.
         if (!iframeWin.IntersectionObserver) {
@@ -3024,6 +3049,31 @@ describe('IntersectionObserver', function() {
             done();
           }
         ], done);
+      });
+
+      it('handles tracking iframe viewport', function(done) {
+        iframe.style.height = '100px';
+        // {root:iframeDoc} means to track the iframe viewport irrespective of toplevel viewport
+        var io = new IntersectionObserver(
+          function (records) {
+            var subviewportWidth =
+              iframeDoc.documentElement.clientWidth || iframeDoc.body.clientWidth;
+            var subviewportHeight =
+              iframeDoc.documentElement.clientHeight || iframeDoc.body.clientHeight;
+
+            expect(records.length).to.be(1);
+            expect(records[0].rootBounds.top).to.be(0);
+            expect(records[0].rootBounds.left).to.be(0);
+            expect(records[0].rootBounds.right).to.be(subviewportWidth);
+            expect(records[0].rootBounds.width).to.be(subviewportWidth);
+            expect(records[0].rootBounds.bottom).to.be(subviewportHeight);
+            expect(records[0].rootBounds.height).to.be(subviewportHeight);
+            done();
+          },
+          { root: iframeDoc }
+        );
+
+        io.observe(iframeTargetEl1);
       });
     });
   });

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -73,7 +73,7 @@ describe('IntersectionObserver', function() {
       expect(io.root).to.be(document);
 
       io = new IntersectionObserver(noop, {root: rootEl});
-      expect(io.root).to.be(rootEl); 
+      expect(io.root).to.be(rootEl);
     });
 
 
@@ -1403,11 +1403,21 @@ describe('IntersectionObserver', function() {
 
       it('handles tracking iframe viewport', function(done) {
         iframe.style.height = '100px';
+        iframe.style.top = '100px';
+        iframeWin.scrollTo(0, 110);
         // {root:iframeDoc} means to track the iframe viewport irrespective of toplevel viewport
         var io = new IntersectionObserver(
           function (records) {
+
+            var intersectionRect = rect({
+              top: 0, // if root=null, then this would be 100.
+              left: 0,
+              height: 90,
+              width: bodyWidth,
+            })
             expect(records.length).to.be(1);
             expect(rect(records[0].rootBounds)).to.eql(getRootRect(iframeDoc));
+            expect(rect(records[0].intersectionRect)).to.eql(intersectionRect);
             done();
           },
           { root: iframeDoc }
@@ -3043,11 +3053,20 @@ describe('IntersectionObserver', function() {
 
       it('handles tracking iframe viewport', function(done) {
         iframe.style.height = '100px';
+        iframe.style.top = '100px';
+        iframeWin.scrollTo(0, 110);
         // {root:iframeDoc} means to track the iframe viewport irrespective of toplevel viewport
         var io = new IntersectionObserver(
           function (records) {
+            var intersectionRect = rect({
+              top: 0, // if root=null, then this would be 100.
+              left: 0,
+              height: 90,
+              width: bodyWidth,
+            })
             expect(records.length).to.be(1);
             expect(rect(records[0].rootBounds)).to.eql(getRootRect(iframeDoc));
+            expect(rect(records[0].intersectionRect)).to.eql(intersectionRect);
             done();
           },
           { root: iframeDoc }

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -1408,6 +1408,7 @@ describe('IntersectionObserver', function() {
         // {root:iframeDoc} means to track the iframe viewport irrespective of toplevel viewport
         var io = new IntersectionObserver(
           function (records) {
+            io.unobserve(iframeTargetEl1);
 
             var intersectionRect = rect({
               top: 0, // if root=null, then this would be 100.
@@ -1421,6 +1422,32 @@ describe('IntersectionObserver', function() {
             done();
           },
           { root: iframeDoc }
+        );
+
+        io.observe(iframeTargetEl1);
+      });
+
+      // Current spec indicates that cross-document tracking yields
+      // an essentially empty IntersectionObserverEntry.
+      // See:
+      it('Does not track cross-document elements', function(done) {
+        var io = new IntersectionObserver(
+          function (records) {
+            io.unobserve(iframeTargetEl1)
+
+            expect(records.length).to.be(1);
+            const zeroesRect = rect({
+              top: 0,
+              left: 0,
+              width: 0,
+              height: 0
+            });
+            expect(rect(records[0].rootBounds)).to.eql(zeroesRect);
+            expect(rect(records[0].intersectionRect)).to.eql(zeroesRect);
+            expect(records.isIntersecting).false;
+            done();
+          },
+          { root: document }
         );
 
         io.observe(iframeTargetEl1);
@@ -3056,8 +3083,9 @@ describe('IntersectionObserver', function() {
         iframe.style.top = '100px';
         iframeWin.scrollTo(0, 110);
         // {root:iframeDoc} means to track the iframe viewport irrespective of toplevel viewport
-        var io = new IntersectionObserver(
+        var io = createObserver(
           function (records) {
+            io.unobserve(iframeTargetEl1);
             var intersectionRect = rect({
               top: 0, // if root=null, then this would be 100.
               left: 0,

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -1414,14 +1414,45 @@ describe('IntersectionObserver', function() {
               top: 0, // if root=null, then this would be 100.
               left: 0,
               height: 90,
-              width: bodyWidth,
-            })
+              width: bodyWidth
+            });
             expect(records.length).to.be(1);
             expect(rect(records[0].rootBounds)).to.eql(getRootRect(iframeDoc));
             expect(rect(records[0].intersectionRect)).to.eql(intersectionRect);
             done();
           },
           { root: iframeDoc }
+        );
+
+        io.observe(iframeTargetEl1);
+      });
+
+      it('handles tracking iframe viewport with rootMargin', function(done) {
+        iframe.style.height = '100px';
+
+        var io =  new IntersectionObserver(
+          function (records) {
+            io.unobserve(iframeTargetEl1);
+            var intersectionRect = rect({
+              top: 0, // if root=null, then this would be 100.
+              left: 0,
+              height: 200,
+              width: bodyWidth
+            });
+
+            // rootMargin: 100% --> 3x width + 3x height.
+            var expectedRootBounds = rect({
+              top: -100,
+              left: -bodyWidth,
+              width: bodyWidth * 3,
+              height: 100 * 3
+            });
+            expect(records.length).to.be(1);
+            expect(rect(records[0].rootBounds)).to.eql(expectedRootBounds);
+            expect(rect(records[0].intersectionRect)).to.eql(intersectionRect);
+            done();
+          },
+          { root: iframeDoc, rootMargin: '100%' }
         );
 
         io.observe(iframeTargetEl1);

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -1652,10 +1652,10 @@ describe('IntersectionObserver', function() {
       var ASYNC_TIMEOUT = 300;
 
       beforeEach(function(done) {
-        // /* Uncomment these lines to force polyfill inside the iframe.
+        /* Uncomment these lines to force polyfill inside the iframe.
         delete iframeWin.IntersectionObserver;
         delete iframeWin.IntersectionObserverEntry;
-        // */
+        */
 
         // Install polyfill right into the iframe.
         if (!iframeWin.IntersectionObserver) {
@@ -2315,10 +2315,10 @@ describe('IntersectionObserver', function() {
       beforeEach(function(done) {
         Object.defineProperty(iframeWin, 'frameElement', {value: null});
 
-        // /* Uncomment these lines to force polyfill inside the iframe.
+        /* Uncomment these lines to force polyfill inside the iframe.
         delete iframeWin.IntersectionObserver;
         delete iframeWin.IntersectionObserverEntry;
-        // */
+        */
 
         // Install polyfill right into the iframe.
         if (!iframeWin.IntersectionObserver) {

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -1405,7 +1405,7 @@ describe('IntersectionObserver', function() {
         iframe.style.height = '100px';
         iframe.style.top = '100px';
         iframeWin.scrollTo(0, 110);
-        // {root:iframeDoc} means to track the iframe viewport irrespective of toplevel viewport
+        // {root:iframeDoc} means to track the iframe viewport.
         var io = new IntersectionObserver(
           function (records) {
             io.unobserve(iframeTargetEl1);
@@ -1429,7 +1429,7 @@ describe('IntersectionObserver', function() {
 
       // Current spec indicates that cross-document tracking yields
       // an essentially empty IntersectionObserverEntry.
-      // See:
+      // See: https://github.com/w3c/IntersectionObserver/issues/87
       it('Does not track cross-document elements', function(done) {
         var io = new IntersectionObserver(
           function (records) {
@@ -3082,7 +3082,7 @@ describe('IntersectionObserver', function() {
         iframe.style.height = '100px';
         iframe.style.top = '100px';
         iframeWin.scrollTo(0, 110);
-        // {root:iframeDoc} means to track the iframe viewport irrespective of toplevel viewport
+        // {root:iframeDoc} means to track the iframe viewport.
         var io = createObserver(
           function (records) {
             io.unobserve(iframeTargetEl1);
@@ -3090,7 +3090,7 @@ describe('IntersectionObserver', function() {
               top: 0, // if root=null, then this would be 100.
               left: 0,
               height: 90,
-              width: bodyWidth,
+              width: bodyWidth
             })
             expect(records.length).to.be(1);
             expect(rect(records[0].rootBounds)).to.eql(getRootRect(iframeDoc));

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -1430,7 +1430,7 @@ describe('IntersectionObserver', function() {
       // Current spec indicates that cross-document tracking yields
       // an essentially empty IntersectionObserverEntry.
       // See: https://github.com/w3c/IntersectionObserver/issues/87
-      it('Does not track cross-document elements', function(done) {
+      it('does not track cross-document elements', function(done) {
         var io = new IntersectionObserver(
           function (records) {
             io.unobserve(iframeTargetEl1)
@@ -3091,13 +3091,44 @@ describe('IntersectionObserver', function() {
               left: 0,
               height: 90,
               width: bodyWidth
-            })
+            });
             expect(records.length).to.be(1);
             expect(rect(records[0].rootBounds)).to.eql(getRootRect(iframeDoc));
             expect(rect(records[0].intersectionRect)).to.eql(intersectionRect);
             done();
           },
           { root: iframeDoc }
+        );
+
+        io.observe(iframeTargetEl1);
+      });
+
+      it('handles tracking iframe viewport with rootMargin', function(done) {
+        iframe.style.height = '100px';
+
+        var io = createObserver(
+          function (records) {
+            io.unobserve(iframeTargetEl1);
+            var intersectionRect = rect({
+              top: 0, // if root=null, then this would be 100.
+              left: 0,
+              height: 200,
+              width: bodyWidth
+            });
+
+            // rootMargin: 100% --> 3x width + 3x height.
+            var expectedRootBounds = rect({
+              top: -100,
+              left: -bodyWidth,
+              width: bodyWidth * 3,
+              height: 100 * 3
+            });
+            expect(records.length).to.be(1);
+            expect(rect(records[0].rootBounds)).to.eql(expectedRootBounds);
+            expect(rect(records[0].intersectionRect)).to.eql(intersectionRect);
+            done();
+          },
+          { root: iframeDoc, rootMargin: '100%' }
         );
 
         io.observe(iframeTargetEl1);

--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -1406,18 +1406,8 @@ describe('IntersectionObserver', function() {
         // {root:iframeDoc} means to track the iframe viewport irrespective of toplevel viewport
         var io = new IntersectionObserver(
           function (records) {
-            var subviewportWidth =
-              iframeDoc.documentElement.clientWidth || iframeDoc.body.clientWidth;
-            var subviewportHeight =
-              iframeDoc.documentElement.clientHeight || iframeDoc.body.clientHeight;
-
             expect(records.length).to.be(1);
-            expect(records[0].rootBounds.top).to.be(0);
-            expect(records[0].rootBounds.left).to.be(0);
-            expect(records[0].rootBounds.right).to.be(subviewportWidth);
-            expect(records[0].rootBounds.width).to.be(subviewportWidth);
-            expect(records[0].rootBounds.bottom).to.be(subviewportHeight);
-            expect(records[0].rootBounds.height).to.be(subviewportHeight);
+            expect(rect(records[0].rootBounds)).to.eql(getRootRect(iframeDoc));
             done();
           },
           { root: iframeDoc }
@@ -3056,18 +3046,8 @@ describe('IntersectionObserver', function() {
         // {root:iframeDoc} means to track the iframe viewport irrespective of toplevel viewport
         var io = new IntersectionObserver(
           function (records) {
-            var subviewportWidth =
-              iframeDoc.documentElement.clientWidth || iframeDoc.body.clientWidth;
-            var subviewportHeight =
-              iframeDoc.documentElement.clientHeight || iframeDoc.body.clientHeight;
-
             expect(records.length).to.be(1);
-            expect(records[0].rootBounds.top).to.be(0);
-            expect(records[0].rootBounds.left).to.be(0);
-            expect(records[0].rootBounds.right).to.be(subviewportWidth);
-            expect(records[0].rootBounds.width).to.be(subviewportWidth);
-            expect(records[0].rootBounds.bottom).to.be(subviewportHeight);
-            expect(records[0].rootBounds.height).to.be(subviewportHeight);
+            expect(rect(records[0].rootBounds)).to.eql(getRootRect(iframeDoc));
             done();
           },
           { root: iframeDoc }

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -504,7 +504,7 @@ IntersectionObserver.prototype._checkForIntersections = function() {
     if (!this._rootContainsTarget(target)) {
       rootBounds = getEmptyRect();
     } else if (!crossOriginUpdater || this.root) {
-      rootBounds = rootRect
+      rootBounds = rootRect;
     }
 
     var newEntry = item.entry = new IntersectionObserverEntry({
@@ -718,9 +718,7 @@ IntersectionObserver.prototype._hasCrossedThreshold =
  * @private
  */
 IntersectionObserver.prototype._rootIsInDom = function() {
-  var rootDoc =
-    (this.root && (this.root.ownerDocument || this.root)) || document;
-  return !this.root || containsDeep(rootDoc, this.root);
+  return !this.root || containsDeep(document, this.root);
 };
 
 
@@ -734,7 +732,7 @@ IntersectionObserver.prototype._rootContainsTarget = function(target) {
   var rootDoc =
     (this.root && (this.root.ownerDocument || this.root)) || document;
   return (
-    containsDeep(this.root || rootDoc, target) &&
+    containsDeep(rootDoc, target) &&
     (!this.root || rootDoc == target.ownerDocument)
   );
 };
@@ -999,6 +997,11 @@ function getParentNode(node) {
   return parent;
 }
 
+/**
+ * Returns true if `node` is a Document.
+ * @param {!Node} node
+ * @returns {boolean}
+ */
 function isDoc(node) {
   return node && node.nodeType === 9;
 }

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -131,8 +131,12 @@ function IntersectionObserver(callback, opt_options) {
     throw new Error('callback must be a function');
   }
 
-  if (options.root && options.root.nodeType != 1) {
-    throw new Error('root must be an Element');
+  if (
+    options.root &&
+    options.root.nodeType != 1 &&
+    options.root.nodeType !== 9
+  ) {
+    throw new Error("root must be a Document or Element");
   }
 
   // Binds and throttles `this._checkForIntersections`.

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -500,11 +500,18 @@ IntersectionObserver.prototype._checkForIntersections = function() {
     var intersectionRect = rootIsInDom && rootContainsTarget &&
         this._computeTargetAndRootIntersection(target, targetRect, rootRect);
 
+    var rootBounds = null;
+    if (!this._rootContainsTarget(target)) {
+      rootBounds = getEmptyRect();
+    } else if (!crossOriginUpdater || this.root) {
+      rootBounds = rootRect
+    }
+
     var newEntry = item.entry = new IntersectionObserverEntry({
       time: now(),
       target: target,
       boundingClientRect: targetRect,
-      rootBounds: crossOriginUpdater && !this.root ? null : rootRect,
+      rootBounds: rootBounds,
       intersectionRect: intersectionRect
     });
 
@@ -711,7 +718,9 @@ IntersectionObserver.prototype._hasCrossedThreshold =
  * @private
  */
 IntersectionObserver.prototype._rootIsInDom = function() {
-  return !this.root || containsDeep(document, this.root);
+  var rootDoc =
+    (this.root && (this.root.ownerDocument || this.root)) || document;
+  return !this.root || containsDeep(rootDoc, this.root);
 };
 
 

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -638,7 +638,7 @@ IntersectionObserver.prototype._getRootRect = function() {
       right: html.clientWidth || body.clientWidth,
       width: html.clientWidth || body.clientWidth,
       bottom: html.clientHeight || body.clientHeight,
-      height: html.clientHeight || body.clientHeight,
+      height: html.clientHeight || body.clientHeight
     };
   }
   return this._expandRectByRootMargin(rootRect);

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -134,9 +134,9 @@ function IntersectionObserver(callback, opt_options) {
   if (
     options.root &&
     options.root.nodeType != 1 &&
-    options.root.nodeType !== 9
+    options.root.nodeType != 9
   ) {
-    throw new Error("root must be a Document or Element");
+    throw new Error('root must be a Document or Element');
   }
 
   // Binds and throttles `this._checkForIntersections`.
@@ -399,10 +399,9 @@ IntersectionObserver.prototype._monitorIntersections = function(doc) {
   });
 
   // Also monitor the parent.
-  if (
-    doc != ((this.root && this.root.ownerDocument) || document) &&
-    !isDoc(this.root)
-  ) {
+  var rootDoc =
+    (this.root && (this.root.ownerDocument || this.root)) || document;
+  if (doc != rootDoc) {
     var frame = getFrameElement(doc);
     if (frame) {
       this._monitorIntersections(frame.ownerDocument);
@@ -422,9 +421,8 @@ IntersectionObserver.prototype._unmonitorIntersections = function(doc) {
     return;
   }
 
-  var rootDoc = isDoc(this.root)
-    ? this.root
-    : (this.root && this.root.ownerDocument) || document;
+  var rootDoc =
+    (this.root && (this.root.ownerDocument || this.root)) || document;
 
   // Check if any dependent targets are still remaining.
   var hasDependentTargets =
@@ -631,8 +629,9 @@ IntersectionObserver.prototype._getRootRect = function() {
     rootRect = getBoundingClientRect(this.root);
   } else {
     // Use <html>/<body> instead of window since scroll bars affect size.
-    var html = document.documentElement;
-    var body = document.body;
+    var doc = isDoc(this.root) ? this.root : document;
+    var html = doc.documentElement;
+    var body = doc.body;
     rootRect = {
       top: 0,
       left: 0,
@@ -723,9 +722,10 @@ IntersectionObserver.prototype._rootIsInDom = function() {
  * @private
  */
 IntersectionObserver.prototype._rootContainsTarget = function(target) {
-  const rootDoc = isDoc(this.root) ? this.root : this.root.ownerDocument;
+  var rootDoc =
+    (this.root && (this.root.ownerDocument || this.root)) || document;
   return (
-    containsDeep(this.root || document, target) &&
+    containsDeep(this.root || rootDoc, target) &&
     (!this.root || rootDoc == target.ownerDocument)
   );
 };

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intersection-observer",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A polyfill for IntersectionObserver",
   "main": "intersection-observer",
   "repository": {


### PR DESCRIPTION
**summary**
Implements iframe viewport tracking for the polyfill, as described in https://github.com/w3c/IntersectionObserver/issues/372#issuecomment-575287674.

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation already completed:

 * [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=208047)
 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=1015183)
 * [x] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1617154)


cc @dvoytenko 