### PR TITLE
iframed inob: top should be in reference to Window

### DIFF
--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -1054,6 +1054,26 @@ describe('IntersectionObserver', function() {
         io.observe(iframeTargetEl2);
       });
 
+      it.only('handles tracking iframe viewport', function(done) {
+        iframe.style.top = '100px';
+        var io = new IntersectionObserver(
+          function (records) {
+            debugger;
+            var intersectionRect = rect({
+              top: 100,
+              left: 0,
+              height: 200,
+              width: bodyWidth,
+            })
+            expect(records.length).to.be(1);
+            expect(rect(records[0].rootBounds)).to.eql(getRootRect(document));
+            expect(rect(records[0].intersectionRect)).to.eql(intersectionRect);
+            done();
+        });
+
+        io.observe(iframeTargetEl1);
+      });
+
       it('triggers for all targets in top-level root', function(done) {
         var io = new IntersectionObserver(function(unsortedRecords) {
           var records = sortRecords(unsortedRecords);


### PR DESCRIPTION
Does this test case demonstrate a bug?

Assuming an InOb within an iframe that is tracking the viewport (root=null), if the iframe is fixed position and `top:100`, then I'd expect the intersection within it at `y=0` to have an intersection rect with `y=100`.

cc @dvoytenko 