### PR TITLE
Remove incorrect sentence about explicit root observers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -198,9 +198,6 @@ a <a>target</a> whose <a>relevant settings object</a>'s <a>origin</a> is
 <a>same origin-domain</a> with the <a>top-level origin</a>, referred to as a
 <dfn for="IntersectionObserver">same-origin-domain target</dfn>;
 as opposed to a <dfn for="IntersectionObserver">cross-origin-domain target</dfn>.
-Any <a>target</a> of an <a>explicit root observer</a> is also a <a>same-origin-domain target</a>,
-since the <a>target</a> must be in the same <a>document</a> as the
-<a>intersection root</a>.
 
 Note: In {{MutationObserver}}, the {{MutationObserverInit}} options are passed
 to {{MutationObserver/observe()}} while in {{IntersectionObserver}} they are


### PR DESCRIPTION
As discussed with @szager-chromium the other day, the sentence that I'm removing in this PR is incorrect. A target of an explicit root observer certainly does not have to be a same-origin-domain target, because you can provide an explicit root in cross-origin subframes, but in said subframes the target's setting's object's origin is of course cross-origin with that of the top-level one.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/domfarolino/IntersectionObserver/pull/483.html" title="Last updated on Sep 30, 2021, 2:42 AM UTC (f0e5858)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/483/cac7ad2...domfarolino:f0e5858.html" title="Last updated on Sep 30, 2021, 2:42 AM UTC (f0e5858)">Diff</a>