### PR TITLE
Allow setting `rootMargin`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -218,7 +218,7 @@ use-cases. Per-{{observe()}} options could be provided in the future if the need
 interface IntersectionObserver {
 	constructor(IntersectionObserverCallback callback, optional IntersectionObserverInit options = {});
 	readonly attribute (Element or Document)? root;
-	readonly attribute DOMString rootMargin;
+	         attribute DOMString rootMargin;
 	readonly attribute FrozenArray&lt;double&gt; thresholds;
 	undefined observe(Element target);
 	undefined unobserve(Element target);
@@ -279,7 +279,14 @@ interface IntersectionObserver {
 		this is not guaranteed to be identical to the |options|.{{IntersectionObserverInit/rootMargin}}
 		passed to the {{IntersectionObserver}} constructor.  If no
 		{{IntersectionObserverInit/rootMargin}} was passed to the {{IntersectionObserver}}
-		constructor, the value of this attribute is "0px 0px 0px 0px".
+		constructor, and the {{IntersectionObserver/rootMargin}} setter has not been invoked,
+		the value of this attribute is "0px 0px 0px 0px".
+
+		On setting, attempt to <a>parse a root margin</a>
+		from the given value.
+		If a list is returned,
+		set |this|'s internal {{[[rootMargin]]}} slot to that.
+		Otherwise, <a>throw</a> a {{SyntaxError}} exception.
 	: <dfn>thresholds</dfn>
 	::
 		A list of thresholds, sorted in increasing numeric order,


### PR DESCRIPTION
Part of #428.

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/IntersectionObserver/pull/486.html" title="Last updated on Oct 26, 2021, 10:07 PM UTC (9c77efd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/486/cac7ad2...bocoup:9c77efd.html" title="Last updated on Oct 26, 2021, 10:07 PM UTC (9c77efd)">Diff</a>