### PR TITLE
Clarify same-domain-target designation for explicit root observers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -200,9 +200,7 @@ a <a>target</a> whose <a>relevant settings object</a>'s <a>origin</a> is
 <a>same origin-domain</a> with the <a>top-level origin</a>, referred to as a
 <dfn for="IntersectionObserver">same-origin-domain target</dfn>;
 as opposed to a <dfn for="IntersectionObserver">cross-origin-domain target</dfn>.
-Any <a>target</a> of an <a>explicit root observer</a> is also a <a>same-origin-domain target</a>,
-since the <a>target</a> must be in the same <a>document</a> as the
-<a>intersection root</a>.
+Any <a>target</a> of an <a>explicit root observer</a> is treated as a <a>same-origin-domain target</a>.
 
 Note: In {{MutationObserver}}, the {{MutationObserverInit}} options are passed
 to {{MutationObserver/observe()}} while in {{IntersectionObserver}} they are


### PR DESCRIPTION
Based on:

https://github.com/w3c/IntersectionObserver/pull/483


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/pull/491.html" title="Last updated on Apr 11, 2022, 7:27 PM UTC (a2c8ae5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/491/cc4d964...a2c8ae5.html" title="Last updated on Apr 11, 2022, 7:27 PM UTC (a2c8ae5)">Diff</a>