### PR TITLE
chore: fix HTML Event Loops Processing Model link

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -39,7 +39,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/
 		type: dfn; text: queue a task
 		type: dfn; text: run the fullscreen rendering steps
 		type: dfn; text: run the animation frame callbacks
-		url: #processing-model-8; type: dfn; text: HTML Event Loops Processing Model
+		url: #event-loop-processing-model; type: dfn; text: HTML Event Loops Processing Model
 		type: dfn; text: relevant settings object
 		url: #concept-environment-top-level-origin; type: dfn; text: top-level origin
 	urlPrefix: infrastructure.html;
@@ -727,7 +727,7 @@ if there is at least one {{IntersectionObserver}} meeting these criteria:
 		</li>
 	</ol>
 
-In the <a>HTML Processing Model</a>, under the "<i>Update the rendering</i>" step, the "<i>Unnecessary rendering</i>" step should be modified to add an additional requirement for skipping the rendering update:
+In the <a>HTML Event Loops Processing Model</a>, under the "<i>Update the rendering</i>" step, the "<i>Unnecessary rendering</i>" step should be modified to add an additional requirement for skipping the rendering update:
 
 <ul><li>The |document| does not have <a>pending initial IntersectionObserver targets</a>.</li></ul>
 


### PR DESCRIPTION
It seems that the anchor changed at some recent point in the past.

Closes #492 

PTAL @szager-chromium


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/IntersectionObserver/pull/494.html" title="Last updated on Jun 9, 2022, 5:50 PM UTC (26848c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/494/877c310...miketaylr:26848c4.html" title="Last updated on Jun 9, 2022, 5:50 PM UTC (26848c4)">Diff</a>