### PR TITLE
Fix typo in example comment

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -137,7 +137,7 @@ it allows applications to significantly reduce their CPU, GPU and energy costs.
 		for (const change of changes) {
 			console.log(change.time);               // Timestamp when the change occurred
 			console.log(change.rootBounds);         // Unclipped area of root
-			console.log(change.boundingClientRect); // target.boundingClientRect()
+			console.log(change.boundingClientRect); // target.getBoundingClientRect()
 			console.log(change.intersectionRect);   // boundingClientRect, clipped by its containing block ancestors, and intersected with rootBounds
 			console.log(change.intersectionRatio);  // Ratio of intersectionRect area to boundingClientRect area
 			console.log(change.target);             // the Element target


### PR DESCRIPTION
@nolanlawson tried to fix this back in 2017[1], but rather than
deal with merge conflicts, I'm just manually applying the fix.

[1] https://github.com/w3c/IntersectionObserver/pull/228


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/IntersectionObserver/pull/496.html" title="Last updated on Jun 10, 2022, 8:00 PM UTC (8693416)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/496/0528a65...miketaylr:8693416.html" title="Last updated on Jun 10, 2022, 8:00 PM UTC (8693416)">Diff</a>