### PR TITLE
Add Scroll Margin to Intersection Observer

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -381,6 +381,8 @@ Percentages are resolved relative to the width of the undilated rectangle.
 
 Note: {{IntersectionObserver/scrollMargin}} affects the clipping of <a for="IntersectionObserver">target</a>
 by all scrollable ancestors up to and including the <a>intersection root</a>.
+Both the {{IntersectionObserver/scrollMargin}} and the {{IntersectionObserver/rootMargin}}
+are applied to a scrollable <a>intersection root's</a> rectangle.
 
 Note: <a>scrollport</a> intersection rectangles are not affected by
 <a>pinch zoom</a> and will report the unadjusted <a>viewport</a>, consistent with the

--- a/index.bs
+++ b/index.bs
@@ -286,7 +286,7 @@ interface IntersectionObserver {
 		constructor, the value of this attribute is "0px 0px 0px 0px".
 	: <dfn>scrollMargin</dfn>
 	::
-		Offsets are applied to <a>scrollable intersection rectangles</a>,
+		Offsets are applied to <a>scrollports</a> on the path from <a>intersection root</a> to <a for="IntersectionObserver">target</a>,
 		effectively growing or shrinking the box that is used to calculate intersections.
 		<b>These offsets are only applied when handling <a>same-origin-domain targets</a>;
 		for <a>cross-origin-domain targets</a> they are ignored.</b>
@@ -371,14 +371,8 @@ or failure:
 	append a duplicate of the second element to |tokens|.
 7. Return |tokens|.
 
-The <dfn for="IntersectionObserver">scrollable intersection rectangles</dfn>
-for an {{IntersectionObserver}}
-are the rectangles of scrollable containers on the path from the
-<a>intersection root</a> to <a for="IntersectionObserver">target</a>
-which could clip the target's rectangle.
-
-When calculating the <a>scrollable intersection rectangles</a> for
-a <a>same-origin-domain target</a>, the rectangle is then expanded
+When calculating a <a>scrollport</a> intersection rectangle for
+a <a>same-origin-domain target</a>, the rectangle is expanded
 according to the offsets in the {{IntersectionObserver}}’s {{[[scrollMargin]]}} slot
 in a manner similar to CSS's 'margin' property,
 with the four values indicating the amount the top, right, bottom, and left edges, respectively, are offset by,
@@ -388,7 +382,7 @@ Percentages are resolved relative to the width of the undilated rectangle.
 Note: {{IntersectionObserver/scrollMargin}} affects the clipping of <a for="IntersectionObserver">target</a>
 by all scrollable ancestors up to and including the <a>intersection root</a>.
 
-Note: <a>scrollable intersection rectangles</a> are not affected by
+Note: <a>scrollport</a> intersection rectangles are not affected by
 <a>pinch zoom</a> and will report the unadjusted <a>viewport</a>, consistent with the
 intent of pinch zooming (to act like a magnifying glass and NOT change layout.)
 

--- a/index.bs
+++ b/index.bs
@@ -501,6 +501,7 @@ The IntersectionObserverInit dictionary</h3>
 dictionary IntersectionObserverInit {
 	(Element or Document)?  root = null;
 	DOMString rootMargin = "0px";
+	DOMString scrollMargin = "";
 	(double or sequence&lt;double>) threshold = 0;
 };
 </pre>
@@ -517,6 +518,18 @@ dictionary IntersectionObserverInit {
 		each either an <a>absolute length</a> or a percentage.
 
 		<pre class="example" highlight=js>
+			"5px"                // all margins set to 5px
+			"5px 10px"           // top & bottom = 5px, right & left = 10px
+			"-10px 5px 8px"      // top = -10px, right & left = 5px, bottom = 8px
+			"-10px -5px 5px 8px" // top = -10px, right = -5px, bottom = 5px, left = 8px
+		</pre>
+	: <dfn>scrollMargin</dfn>
+	::
+		This is a string of 0-4 components,
+		each either an <a>absolute length</a> or a percentage.
+
+		<pre class="example" highlight=js>
+			""                   // no scroll margins
 			"5px"                // all margins set to 5px
 			"5px 10px"           // top & bottom = 5px, right & left = 10px
 			"-10px 5px 8px"      // top = -10px, right & left = 5px, bottom = 8px

--- a/index.bs
+++ b/index.bs
@@ -604,15 +604,20 @@ and an {{IntersectionObserverInit}} dictionary |options|, run these steps:
 	If a list is returned,
 	set |this|'s internal {{[[rootMargin]]}} slot to that.
 	Otherwise, <a>throw</a> a {{SyntaxError}} exception.
-4. Let |thresholds| be a list equal to
+4. Attempt to <a>parse a scroll margin</a>
+	from |options|.{{IntersectionObserverInit/scrollMargin}}.
+	If a list is returned,
+	set |this|'s internal {{[[scrollMargin]]}} slot to that.
+	Otherwise, <a>throw</a> a {{SyntaxError}} exception.
+5. Let |thresholds| be a list equal to
 	|options|.{{IntersectionObserverInit/threshold}}.
-5. If any value in |thresholds| is less than 0.0 or greater than
+6. If any value in |thresholds| is less than 0.0 or greater than
 	1.0, <a>throw</a> a {{RangeError}} exception.
-6. Sort |thresholds| in ascending order.
-7. If |thresholds| is empty, append <code>0</code> to |thresholds|.
-8. The {{IntersectionObserver/thresholds}} attribute getter will return
+7. Sort |thresholds| in ascending order.
+8. If |thresholds| is empty, append <code>0</code> to |thresholds|.
+9. The {{IntersectionObserver/thresholds}} attribute getter will return
 	this sorted |thresholds| list.
-9. Return |this|.
+10. Return |this|.
 
 <h4 id='observe-target-element'>Observe a target Element</h4>
 

--- a/index.bs
+++ b/index.bs
@@ -587,7 +587,9 @@ which are initialized to empty lists and an internal
 <dfn attribute for=IntersectionObserver>\[[callback]]</dfn> slot
 which is initialized by {{IntersectionObserver(callback, options)}}</a>.
 They also have an internal <dfn attribute for=IntersectionObserver>\[[rootMargin]]</dfn> slot
-which is a list of four pixel lengths or percentages.
+which is a list of four pixel lengths or percentages, and an internal
+<dfn attribute for=IntersectionObserver>\[[scrollMargin]]</dfn> slot
+which is either an empty list or a list of four pixel lengths or percentages.
 
 <h3 id='algorithms'>
 Algorithms</h2>

--- a/index.bs
+++ b/index.bs
@@ -713,9 +713,11 @@ run these steps:
 		of the {{document}}, and update |container| to be
 		the <a>browsing context container</a> of |container|.
 	2. Map |intersectionRect| to the coordinate space of |container|.
-	3. If |container| has a <a>content clip</a> or a css <a>clip-path</a> property,
+	3. If |container| is scrollable, apply the {{IntersectionObserver}}’s
+		{{[[scrollMargin]]}} to the |container|'s clip rect.
+	4. If |container| has a <a>content clip</a> or a css <a>clip-path</a> property,
 		update |intersectionRect| by applying |container|'s clip.
-	4. If |container| is the root element of a <a>browsing context</a>,
+	5. If |container| is the root element of a <a>browsing context</a>,
 		update |container| to be the <a>browsing context</a>'s {{document}};
 		otherwise, update |container| to be the <a>containing block</a>
 		of |container|.

--- a/index.bs
+++ b/index.bs
@@ -341,36 +341,6 @@ If a <a for="IntersectionObserver">target</a> {{Element}} is clipped by an ances
 <a>intersection root</a>, that clipping is unaffected by
 {{IntersectionObserver/rootMargin}}.
 
-Note: <a>Root intersection rectangle</a> is not affected by
-<a>pinch zoom</a> and will report the unadjusted <a>viewport</a>, consistent with the
-intent of pinch zooming (to act like a magnifying glass and NOT change layout.)
-
-To <dfn>parse a root margin</dfn>
-from an input string |marginString|,
-returning either a list of 4 pixel lengths or percentages,
-or failure:
-
-1. <a>Parse a list of component values</a> |marginString|,
-	storing the result as |tokens|.
-2. Remove all whitespace tokens from |tokens|.
-3. If the length of |tokens| is greater than 4,
-	return failure.
-4. If there are zero elements in |tokens|,
-	set |tokens| to ["0px"].
-5. Replace each |token| in |tokens|:
-	* If |token| is an <a>absolute length</a> <a>dimension</a> token,
-		replace it with a an equivalent pixel length.
-	* If |token| is a <<percentage>> token,
-		replace it with an equivalent percentage.
-	* Otherwise, return failure.
-6. If there is one element in |tokens|,
-	append three duplicates of that element to |tokens|.
-	Otherwise, if there are two elements are |tokens|,
-	append a duplicate of each element to |tokens|.
-	Otherwise, if there are three elements in |tokens|,
-	append a duplicate of the second element to |tokens|.
-7. Return |tokens|.
-
 When calculating a <a>scrollport</a> intersection rectangle for
 a <a>same-origin-domain target</a>, the rectangle is expanded
 according to the offsets in the {{IntersectionObserver}}’s {{[[scrollMargin]]}} slot
@@ -384,22 +354,22 @@ by all scrollable ancestors up to and including the <a>intersection root</a>.
 Both the {{IntersectionObserver/scrollMargin}} and the {{IntersectionObserver/rootMargin}}
 are applied to a scrollable <a>intersection root's</a> rectangle.
 
-Note: <a>scrollport</a> intersection rectangles are not affected by
+Note: <a>Root intersection rectangle</a> and <a>scrollport</a> intersection rectangles are not affected by
 <a>pinch zoom</a> and will report the unadjusted <a>viewport</a>, consistent with the
 intent of pinch zooming (to act like a magnifying glass and NOT change layout.)
 
-To <dfn for="IntersectionObserver">parse a scroll margin</dfn>
-from an input string |scrollMarginString|,
-returning either an empty list, a list of 4 pixel lengths or percentages,
+To <dfn>parse a margin</dfn> (root or scroll)
+from an input string |marginString|,
+returning either a list of 4 pixel lengths or percentages,
 or failure:
 
-1. <a>Parse a list of component values</a> |scrollMarginString|,
+1. <a>Parse a list of component values</a> |marginString|,
 	storing the result as |tokens|.
 2. Remove all whitespace tokens from |tokens|.
 3. If the length of |tokens| is greater than 4,
 	return failure.
 4. If there are zero elements in |tokens|,
-	set |tokens| to [].
+	set |tokens| to ["0px"].
 5. Replace each |token| in |tokens|:
 	* If |token| is an <a>absolute length</a> <a>dimension</a> token,
 		replace it with a an equivalent pixel length.
@@ -497,7 +467,7 @@ The IntersectionObserverInit dictionary</h3>
 dictionary IntersectionObserverInit {
 	(Element or Document)?  root = null;
 	DOMString rootMargin = "0px";
-	DOMString scrollMargin = "";
+	DOMString scrollMargin = "0px";
 	(double or sequence&lt;double>) threshold = 0;
 };
 </pre>
@@ -521,16 +491,11 @@ dictionary IntersectionObserverInit {
 		</pre>
 	: <dfn>scrollMargin</dfn>
 	::
-		This is a string of 0-4 components,
+		Similar to {{IntersectionObserverInit/rootMargin}},
+		this is a string of 1-4 components,
 		each either an <a>absolute length</a> or a percentage.
 
-		<pre class="example" highlight=js>
-			""                   // no scroll margins
-			"5px"                // all margins set to 5px
-			"5px 10px"           // top & bottom = 5px, right & left = 10px
-			"-10px 5px 8px"      // top = -10px, right & left = 5px, bottom = 8px
-			"-10px -5px 5px 8px" // top = -10px, right = -5px, bottom = 5px, left = 8px
-		</pre>
+		See {{IntersectionObserverInit/rootMargin}} above for the example.
 	: <dfn>threshold</dfn>
 	::
 		List of threshold(s) at which to trigger callback.
@@ -597,12 +562,12 @@ and an {{IntersectionObserverInit}} dictionary |options|, run these steps:
 
 1. Let |this| be a new {{IntersectionObserver}} object
 2. Set |this|'s internal {{[[callback]]}} slot to |callback|.
-3. Attempt to <a>parse a root margin</a>
+3. Attempt to <a>parse a margin</a>
 	from |options|.{{IntersectionObserverInit/rootMargin}}.
 	If a list is returned,
 	set |this|'s internal {{[[rootMargin]]}} slot to that.
 	Otherwise, <a>throw</a> a {{SyntaxError}} exception.
-4. Attempt to <a>parse a scroll margin</a>
+4. Attempt to <a>parse a margin</a>
 	from |options|.{{IntersectionObserverInit/scrollMargin}}.
 	If a list is returned,
 	set |this|'s internal {{[[scrollMargin]]}} slot to that.

--- a/index.bs
+++ b/index.bs
@@ -287,7 +287,7 @@ interface IntersectionObserver {
 	: <dfn>scrollMargin</dfn>
 	::
 		Offsets are applied to <a>scrollports</a> on the path from <a>intersection root</a> to <a for="IntersectionObserver">target</a>,
-		effectively growing or shrinking the boxes that are used to calculate intersections.
+		effectively growing or shrinking the clip rects used to calculate intersections.
 		<b>These offsets are only applied when handling <a>same-origin-domain targets</a>;
 		for <a>cross-origin-domain targets</a> they are ignored.</b>
 

--- a/index.bs
+++ b/index.bs
@@ -287,7 +287,7 @@ interface IntersectionObserver {
 	: <dfn>scrollMargin</dfn>
 	::
 		Offsets are applied to <a>scrollports</a> on the path from <a>intersection root</a> to <a for="IntersectionObserver">target</a>,
-		effectively growing or shrinking the box that is used to calculate intersections.
+		effectively growing or shrinking the boxes that are used to calculate intersections.
 		<b>These offsets are only applied when handling <a>same-origin-domain targets</a>;
 		for <a>cross-origin-domain targets</a> they are ignored.</b>
 
@@ -297,7 +297,7 @@ interface IntersectionObserver {
 		this is not guaranteed to be identical to the |options|.{{IntersectionObserverInit/scrollMargin}}
 		passed to the {{IntersectionObserver}} constructor.  If no
 		{{IntersectionObserverInit/scrollMargin}} was passed to the {{IntersectionObserver}}
-		constructor, the value of this attribute is an empty string.
+		constructor, the value of this attribute is "0px 0px 0px 0px".
 	: <dfn>thresholds</dfn>
 	::
 		A list of thresholds, sorted in increasing numeric order,
@@ -547,10 +547,9 @@ IntersectionObserver</h4>
 which are initialized to empty lists and an internal
 <dfn attribute for=IntersectionObserver>\[[callback]]</dfn> slot
 which is initialized by {{IntersectionObserver(callback, options)}}</a>.
-They also have an internal <dfn attribute for=IntersectionObserver>\[[rootMargin]]</dfn> slot
-which is a list of four pixel lengths or percentages, and an internal
-<dfn attribute for=IntersectionObserver>\[[scrollMargin]]</dfn> slot
-which is either an empty list or a list of four pixel lengths or percentages.
+They also have internal <dfn attribute for=IntersectionObserver>\[[rootMargin]]</dfn>
+and <dfn attribute for=IntersectionObserver>\[[scrollMargin]]</dfn> slots
+which are lists of four pixel lengths or percentages.
 
 <h3 id='algorithms'>
 Algorithms</h2>

--- a/index.bs
+++ b/index.bs
@@ -222,6 +222,7 @@ interface IntersectionObserver {
 	constructor(IntersectionObserverCallback callback, optional IntersectionObserverInit options = {});
 	readonly attribute (Element or Document)? root;
 	readonly attribute DOMString rootMargin;
+	readonly attribute DOMString scrollMargin;
 	readonly attribute FrozenArray&lt;double&gt; thresholds;
 	undefined observe(Element target);
 	undefined unobserve(Element target);
@@ -283,6 +284,20 @@ interface IntersectionObserver {
 		passed to the {{IntersectionObserver}} constructor.  If no
 		{{IntersectionObserverInit/rootMargin}} was passed to the {{IntersectionObserver}}
 		constructor, the value of this attribute is "0px 0px 0px 0px".
+	: <dfn>scrollMargin</dfn>
+	::
+		Offsets are applied to <a>scrollable intersection rectangles</a>,
+		effectively growing or shrinking the box that is used to calculate intersections.
+		<b>These offsets are only applied when handling <a>same-origin-domain targets</a>;
+		for <a>cross-origin-domain targets</a> they are ignored.</b>
+
+		On getting, return the result of serializing the elements of {{[[scrollMargin]]}}
+		space-separated, where pixel lengths serialize as the numeric value followed by "px",
+		and percentages serialize as the numeric value followed by "%".  Note that
+		this is not guaranteed to be identical to the |options|.{{IntersectionObserverInit/scrollMargin}}
+		passed to the {{IntersectionObserver}} constructor.  If no
+		{{IntersectionObserverInit/scrollMargin}} was passed to the {{IntersectionObserver}}
+		constructor, the value of this attribute is an empty string.
 	: <dfn>thresholds</dfn>
 	::
 		A list of thresholds, sorted in increasing numeric order,
@@ -342,6 +357,53 @@ or failure:
 	return failure.
 4. If there are zero elements in |tokens|,
 	set |tokens| to ["0px"].
+5. Replace each |token| in |tokens|:
+	* If |token| is an <a>absolute length</a> <a>dimension</a> token,
+		replace it with a an equivalent pixel length.
+	* If |token| is a <<percentage>> token,
+		replace it with an equivalent percentage.
+	* Otherwise, return failure.
+6. If there is one element in |tokens|,
+	append three duplicates of that element to |tokens|.
+	Otherwise, if there are two elements are |tokens|,
+	append a duplicate of each element to |tokens|.
+	Otherwise, if there are three elements in |tokens|,
+	append a duplicate of the second element to |tokens|.
+7. Return |tokens|.
+
+The <dfn for="IntersectionObserver">scrollable intersection rectangles</dfn>
+for an {{IntersectionObserver}}
+are the rectangles of scrollable containers on the path from the
+<a>intersection root</a> to <a for="IntersectionObserver">target</a>
+which could clip the target's rectangle.
+
+When calculating the <a>scrollable intersection rectangles</a> for
+a <a>same-origin-domain target</a>, the rectangle is then expanded
+according to the offsets in the {{IntersectionObserver}}’s {{[[scrollMargin]]}} slot
+in a manner similar to CSS's 'margin' property,
+with the four values indicating the amount the top, right, bottom, and left edges, respectively, are offset by,
+with positive lengths indicating an outward offset.
+Percentages are resolved relative to the width of the undilated rectangle.
+
+Note: {{IntersectionObserver/scrollMargin}} affects the clipping of <a for="IntersectionObserver">target</a>
+by all scrollable ancestors up to and including the <a>intersection root</a>.
+
+Note: <a>scrollable intersection rectangles</a> are not affected by
+<a>pinch zoom</a> and will report the unadjusted <a>viewport</a>, consistent with the
+intent of pinch zooming (to act like a magnifying glass and NOT change layout.)
+
+To <dfn for="IntersectionObserver">parse a scroll margin</dfn>
+from an input string |scrollMarginString|,
+returning either an empty list, a list of 4 pixel lengths or percentages,
+or failure:
+
+1. <a>Parse a list of component values</a> |scrollMarginString|,
+	storing the result as |tokens|.
+2. Remove all whitespace tokens from |tokens|.
+3. If the length of |tokens| is greater than 4,
+	return failure.
+4. If there are zero elements in |tokens|,
+	set |tokens| to [].
 5. Replace each |token| in |tokens|:
 	* If |token| is an <a>absolute length</a> <a>dimension</a> token,
 		replace it with a an equivalent pixel length.

--- a/index.bs
+++ b/index.bs
@@ -845,7 +845,7 @@ it may provide to code running in the context of a cross-origin iframe
 	about the geometry of the global viewport itself,
 	which may be used to deduce the user's hardware configuration.
 	The motivation for disabling the effects of {{IntersectionObserver/rootMargin}}
-	and suppressing {{IntersectionObserverEntry/rootBounds}}
+	and {{IntersectionObserver/scrollMargin}}, and suppressing {{IntersectionObserverEntry/rootBounds}}
 	for <a>cross-origin-domain targets</a> is to prevent such probing.
 
 It should be noted that prior to {{IntersectionObserver}}, web developers

--- a/index.bs
+++ b/index.bs
@@ -374,7 +374,7 @@ or failure:
 When calculating a <a>scrollport</a> intersection rectangle for
 a <a>same-origin-domain target</a>, the rectangle is expanded
 according to the offsets in the {{IntersectionObserver}}’s {{[[scrollMargin]]}} slot
-in a manner similar to CSS's 'margin' property,
+in a manner similar to CSS's <a href="https://www.w3.org/TR/css-box-3/#margins">margin</a> property,
 with the four values indicating the amount the top, right, bottom, and left edges, respectively, are offset by,
 with positive lengths indicating an outward offset.
 Percentages are resolved relative to the width of the undilated rectangle.

--- a/index.bs
+++ b/index.bs
@@ -8,6 +8,7 @@ Previous version: from biblio
 Level: none
 Editor: Stefan Zager, Google, szager@google.com, w3cid 91208
 Editor: Emilio Cobos Álvarez , Mozilla, emilio@mozilla.com, w3cid 106537
+Editor: Traian Captan, Google, tcaptan@google.com, w3cid 137959
 Former Editor: Michael Blain, Google, mpb@google.com, w3cid 73819
 Abstract: This specification describes an API that can be used to understand the visibility and position of DOM elements ("targets") relative to a containing element or to the top-level viewport ("root"). The position is delivered asynchronously and is useful for understanding the visibility of elements and implementing pre-loading and deferred loading of DOM content.
 Group: webapps

--- a/index.bs
+++ b/index.bs
@@ -344,7 +344,7 @@ If a <a for="IntersectionObserver">target</a> {{Element}} is clipped by an ances
 When calculating a <a>scrollport</a> intersection rectangle for
 a <a>same-origin-domain target</a>, the rectangle is expanded
 according to the offsets in the {{IntersectionObserver}}’s {{[[scrollMargin]]}} slot
-in a manner similar to CSS's <a href="https://www.w3.org/TR/css-box-3/#margins">margin</a> property,
+in a manner similar to CSS's 'margin' property,
 with the four values indicating the amount the top, right, bottom, and left edges, respectively, are offset by,
 with positive lengths indicating an outward offset.
 Percentages are resolved relative to the width of the undilated rectangle.
@@ -673,7 +673,7 @@ run these steps:
 		of the {{document}}, and update |container| to be
 		the <a>browsing context container</a> of |container|.
 	2. Map |intersectionRect| to the coordinate space of |container|.
-	3. If |container| is a <a href="https://www.w3.org/TR/css-overflow/#scroll-container">scroll-container</a>, apply the {{IntersectionObserver}}’s
+	3. If |container| is a <a>scroll container</a>, apply the {{IntersectionObserver}}’s
 		{{[[scrollMargin]]}} to the |container|'s clip rect.
 	4. If |container| has a <a>content clip</a> or a css <a>clip-path</a> property,
 		update |intersectionRect| by applying |container|'s clip.

--- a/index.bs
+++ b/index.bs
@@ -673,7 +673,7 @@ run these steps:
 		of the {{document}}, and update |container| to be
 		the <a>browsing context container</a> of |container|.
 	2. Map |intersectionRect| to the coordinate space of |container|.
-	3. If |container| is scrollable, apply the {{IntersectionObserver}}’s
+	3. If |container| is a <a href="https://www.w3.org/TR/css-overflow/#scroll-container">scroll-container</a>, apply the {{IntersectionObserver}}’s
 		{{[[scrollMargin]]}} to the |container|'s clip rect.
 	4. If |container| has a <a>content clip</a> or a css <a>clip-path</a> property,
 		update |intersectionRect| by applying |container|'s clip.


### PR DESCRIPTION
Closes #431

The following tasks have been completed:

 * [ ] Modified Web platform tests ([link to pull request](https://chromium-review.googlesource.com/c/chromium/src/+/4740913))

Implementation commitment:

 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=1469500)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tcaptan-cr/IntersectionObserver/pull/511.html" title="Last updated on Sep 12, 2023, 10:07 PM UTC (41baa1f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/511/9b6715e...tcaptan-cr:41baa1f.html" title="Last updated on Sep 12, 2023, 10:07 PM UTC (41baa1f)">Diff</a>