### PR TITLE
Clarify scrollMargin details

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -288,8 +288,6 @@ interface IntersectionObserver {
 	::
 		Offsets are applied to <a>scrollports</a> on the path from <a>intersection root</a> to <a for="IntersectionObserver">target</a>,
 		effectively growing or shrinking the clip rects used to calculate intersections.
-		<b>These offsets are only applied when handling <a>same-origin-domain targets</a>;
-		for <a>cross-origin-domain targets</a> they are ignored.</b>
 
 		On getting, return the result of serializing the elements of {{[[scrollMargin]]}}
 		space-separated, where pixel lengths serialize as the numeric value followed by "px",
@@ -341,18 +339,23 @@ If a <a for="IntersectionObserver">target</a> {{Element}} is clipped by an ances
 <a>intersection root</a>, that clipping is unaffected by
 {{IntersectionObserver/rootMargin}}.
 
-When calculating a <a>scrollport</a> intersection rectangle for
-a <a>same-origin-domain target</a>, the rectangle is expanded
-according to the offsets in the {{IntersectionObserver}}’s {{[[scrollMargin]]}} slot
-in a manner similar to CSS's 'margin' property,
-with the four values indicating the amount the top, right, bottom, and left edges, respectively, are offset by,
-with positive lengths indicating an outward offset.
-Percentages are resolved relative to the width of the undilated rectangle.
+: To <dfn>apply scroll margin to a scrollport</dfn>
+::
+	When calculating a <a>scrollport</a> intersection rectangle for
+	a <a>same-origin-domain target</a>, the rectangle is expanded
+	according to the offsets in the {{IntersectionObserver}}’s {{[[scrollMargin]]}} slot
+	in a manner similar to CSS's 'margin' property,
+	with the four values indicating the amount the top, right, bottom, and left edges, respectively, are offset by,
+	with positive lengths indicating an outward offset.
+	Percentages are resolved relative to the width of the undilated rectangle.
 
-Note: {{IntersectionObserver/scrollMargin}} affects the clipping of <a for="IntersectionObserver">target</a>
-by all scrollable ancestors up to and including the <a>intersection root</a>.
-Both the {{IntersectionObserver/scrollMargin}} and the {{IntersectionObserver/rootMargin}}
-are applied to a scrollable <a>intersection root's</a> rectangle.
+	<b>These offsets are only applied when handling <a>same-origin-domain targets</a>;
+	for <a>cross-origin-domain targets</a> they are ignored.</b>
+
+	Note: {{IntersectionObserver/scrollMargin}} affects the clipping of <a for="IntersectionObserver">target</a>
+	by all scrollable ancestors up to and including the <a>intersection root</a>.
+	Both the {{IntersectionObserver/scrollMargin}} and the {{IntersectionObserver/rootMargin}}
+	are applied to a scrollable <a>intersection root's</a> rectangle.
 
 Note: <a>Root intersection rectangle</a> and <a>scrollport</a> intersection rectangles are not affected by
 <a>pinch zoom</a> and will report the unadjusted <a>viewport</a>, consistent with the
@@ -674,7 +677,7 @@ run these steps:
 		the <a>browsing context container</a> of |container|.
 	2. Map |intersectionRect| to the coordinate space of |container|.
 	3. If |container| is a <a>scroll container</a>, apply the {{IntersectionObserver}}’s
-		{{[[scrollMargin]]}} to the |container|'s clip rect.
+		{{[[scrollMargin]]}} to the |container|'s clip rect as described in <a>apply scroll margin to a scrollport</a>.
 	4. If |container| has a <a>content clip</a> or a css <a>clip-path</a> property,
 		update |intersectionRect| by applying |container|'s clip.
 	5. If |container| is the root element of a <a>browsing context</a>,


### PR DESCRIPTION
RE: ["I think this content, which is currently intermingled with the definition of root intersection rect, should be moved to the definition of scrollMargin"](https://github.com/w3c/IntersectionObserver/pull/511#issuecomment-1736315746)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tcaptan-cr/IntersectionObserver/pull/515.html" title="Last updated on Sep 29, 2023, 6:43 AM UTC (a47c2fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/515/f22fbf4...tcaptan-cr:a47c2fc.html" title="Last updated on Sep 29, 2023, 6:43 AM UTC (a47c2fc)">Diff</a>