### PR TITLE
Fix thresholds definition to match browsers.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -303,7 +303,8 @@ interface IntersectionObserver {
 		of an observed target.  Notifications for a target are generated when any
 		of the thresholds are crossed for that target.
 		If no |options|.{{IntersectionObserverInit/threshold}} was provided to the
-		{{IntersectionObserver}} constructor, the value of this attribute will be [0].
+		{{IntersectionObserver}} constructor, or the sequence is empty, the value
+		of this attribute will be [0].
 </div>
 
 An {{Element}} is defined as having a <dfn for="IntersectionObserver">content clip</dfn> if its computed style has <a>overflow properties</a> that cause its content to be clipped to the element's padding edge.


### PR DESCRIPTION
https://github.com/web-platform-tests/wpt/commit/8c0296b50bf3974677e024c04d45b3ff8b0e801e tested that thresholds when provided empty is [0].

This is not in the spec, but is reasonable and I'm happy to change Firefox to match this, given both WebKit and Blink do that.

The following tasks have been completed:

 * [ ] Modified Web platform tests: N/A, WPT already tests this.

Implementation commitment:

 * [ ] WebKit: N/A (already has this behavior)
 * [ ] Chromium: N/A (same)
 * [x] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1855836)
