### PR TITLE
Fix overflow clipping.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -58,7 +58,8 @@ urlPrefix: https://heycam.github.io/webidl/
 	url: #hierarchyrequesterror; type: exception; text: HierarchyRequestError
 urlPrefix: https://drafts.csswg.org/css-box/
 	url: #containing-block; type: dfn; text: containing block
-	url: #content-area; type: dfn; text: content area
+	url: #padding-area; type: dfn; text: padding area
+	url: #padding-edge; type: dfn; text: padding edge
 urlPrefix: https://drafts.csswg.org/css-display/
 	url: #containing-block-chain; type: dfn; text: containing block chain
 urlPrefix: http://www.w3.org/TR/css-masking-1/
@@ -307,7 +308,7 @@ interface IntersectionObserver {
 		of this attribute will be [0].
 </div>
 
-An {{Element}} is defined as having a <dfn for="IntersectionObserver">content clip</dfn> if its computed style has <a>overflow properties</a> that cause its content to be clipped to the element's padding edge.
+An {{Element}} is defined as having a <dfn for="IntersectionObserver">content clip</dfn> if its computed style has <a>overflow properties</a> that cause its content to be clipped to the element's <a>padding edge</a>.
 
 The <dfn for=IntersectionObserver>root intersection rectangle</dfn>
 for an {{IntersectionObserver}}
@@ -321,7 +322,7 @@ is the rectangle we'll use to check against the targets.
 	<dd>it's the size of the {{document}}'s <a>viewport</a> (note that this processing step can only be reached if the {{document}} is <a>fully active</a>).
 
 	<dt>Otherwise, if the <a>intersection root</a> has a <a>content clip</a>,
-	<dd>it's the element's <a>content area</a>.
+	<dd>it's the element's <a>padding area</a>.
 
 	<dt>Otherwise,
 	<dd>it's the result of <a>getting the bounding box</a> for the <a>intersection root</a>.


### PR DESCRIPTION
Fixes #504. The overflow property clips to padding edges, so IntersectionObserver should match that clip.

The following tasks have been completed:

 * [x] Modified Web platform tests: https://phabricator.services.mozilla.com/D191277

Browser bugs:

 * [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=263316)
 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=1493643)
 * [x] Gecko (already has this behavior)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/pull/517.html" title="Last updated on Oct 18, 2023, 10:37 AM UTC (efe89d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/517/e1c3797...efe89d8.html" title="Last updated on Oct 18, 2023, 10:37 AM UTC (efe89d8)">Diff</a>