### PR TITLE
Use "invoke" properly

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -704,9 +704,7 @@ run these steps:
 		slot.
 	3. Clear |observer|'s internal {{[[QueuedEntries]]}} slot.
 	4. Let |callback| be the value of |observer|'s internal {{[[callback]]}} slot.
-	5. Invoke |callback| with |queue| as the first argument, |observer| as the second argument,
-		and |observer| as the <a>callback this value</a>.
-		If this throws an exception, <a>report the exception</a>.
+	5. [=Invoke=] |callback| with « |queue|, |observer| », "`report`", and |observer|.
 
 <h4 id='queue-intersection-observer-entry-algo'>
 Queue an IntersectionObserverEntry</h4>


### PR DESCRIPTION
This reflects changes in Web IDL and HTML's exception reporting. See https://github.com/whatwg/html/issues/10516.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/pull/529.html" title="Last updated on May 21, 2025, 7:43 AM UTC (36e266d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IntersectionObserver/529/8f41a7d...36e266d.html" title="Last updated on May 21, 2025, 7:43 AM UTC (36e266d)">Diff</a>