### PR TITLE
Update Makefile to use spec-generator; fix mismatched HTML tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@ SHELL=/bin/bash -o pipefail
 .PHONY: local remote deploy
 
 remote: index.bs
-	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
+	@ (HTTP_STATUS=$$(curl https://www.w3.org/publications/spec-generator/ \
 	                       --output index.html \
 	                       --write-out "%{http_code}" \
 	                       --header "Accept: text/plain, text/html" \
+	                       -F type=bikeshed-spec \
 	                       -F die-on=warning \
 	                       -F md-Text-Macro="COMMIT-SHA LOCAL COPY" \
 	                       -F file=@index.bs) && \

--- a/index.bs
+++ b/index.bs
@@ -609,7 +609,7 @@ IntersectionObserver</h4>
 		which is initialized by {{IntersectionObserver(callback, options)}}.
 
 <h3 id='algorithms'>
-Algorithms</h2>
+Algorithms</h3>
 
 <h4 id='initialize-new-intersection-observer'>Initialize a new IntersectionObserver</h4>
 
@@ -837,7 +837,7 @@ To <dfn export>run the update intersection observations steps</dfn> for a
 			{{IntersectionObserverRegistration/previousIsVisible}} property.
 
 <h3 id='lifetime'>
-IntersectionObserver Lifetime</h2>
+IntersectionObserver Lifetime</h3>
 
 An {{IntersectionObserver}} will remain alive until both of these conditions hold:
 <ul>


### PR DESCRIPTION
This updates the Makefile to use spec-generator for the `remote` target, since the CSSWG Bikeshed service has been discontinued.

This also fixes a couple of mismatched end tags in `index.bs` to allow the current version of Bikeshed (which performs stricter HTML parsing) to succeed. (Let me know if I should back this out of this PR, but I figured including it would be better than having the updated Makefile fail in its current state.)